### PR TITLE
Killing wrapper executable leaves orphaned child process

### DIFF
--- a/bin/phantomjs
+++ b/bin/phantomjs
@@ -13,3 +13,8 @@ var cp = spawn(binPath, args)
 cp.stdout.pipe(process.stdout)
 cp.stderr.pipe(process.stderr)
 cp.on('exit', process.exit)
+
+process.on('SIGTERM', function() {
+  cp.kill('SIGTERM')
+  process.exit(1)
+})


### PR DESCRIPTION
Killing the parent process leaves the phantomjs binary child process
orphaned, unless we forward the signal to the child as well.

This commit handles SIGTERM only. It might perhaps be an idea to do
the same or similar with SIGINT as well.
