### PR TITLE
Use a mirror of the PhantomJS binaries.

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,12 @@ with an additional build number that is used for revisions to the installer.
 As such `1.8.0-1` will `1.8.0-2` will both install PhantomJs 1.8 but the latter
 has newer changes to the installer.
 
+Prior to version 1.8.1 the binaries were downloaded from PhantomJS project
+hosting on Google Code, however, old binaries are no longer archived there so
+this NPM package would break whenever a new version was published. Since 1.8.1
+Obvious have been keeping a mirror on S3 which will ensure old NPM packages will
+continue to work.
+
 A Note on PhantomJS
 -------------------
 

--- a/install.js
+++ b/install.js
@@ -20,17 +20,22 @@ fs.existsSync = fs.existsSync || path.existsSync
 
 var libPath = path.join(__dirname, 'lib', 'phantom')
 var tmpPath = path.join(__dirname, 'tmp')
-var downloadUrl = 'http://phantomjs.googlecode.com/files/phantomjs-1.8.1-'
+
+// PhantomJS only hosts the latest binaries, we'd like old packages to continue working while people
+// upgrade and as such Obvious are mirroring old versions in S3.
+var baseUrl = 'http://obvious.s3.amazonaws.com/mirrors/phantomjs/phantomjs-'
+var version = '1.8.1'
+var downloadUrl = baseUrl + version
 var fileName
 
 if (process.platform === 'linux' && process.arch === 'x64') {
-  downloadUrl += 'linux-x86_64.tar.bz2'
+  downloadUrl += '-linux-x86_64.tar.bz2'
 } else if (process.platform === 'linux') {
-  downloadUrl += 'linux-i686.tar.bz2'
+  downloadUrl += '-linux-i686.tar.bz2'
 } else if (process.platform === 'darwin') {
-  downloadUrl += 'macosx.zip'
+  downloadUrl += '-macosx.zip'
 } else if (process.platform === 'win32') {
-  downloadUrl += 'windows.zip'
+  downloadUrl += '-windows.zip'
 } else {
   console.log('Unexpected platform or architecture:', process.platform, process.arch)
   process.exit(1)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "phantomjs",
-  "version": "1.8.1-1",
+  "version": "1.8.1-2",
   "keywords": ["phantomjs", "headless", "webkit"],
   "description": "Headless WebKit with JS API",
   "homepage": "https://github.com/Obvious/phantomjs",


### PR DESCRIPTION
The rational behind this change is to insulate the NPM package from
removal of old binaries from PhantomJS hosting on Google Code. See
issue #22 for details of breakage.
