### PR TITLE
Changed zip library from unzip to adm-zip.

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "rimraf": "~2.0.2",
-    "unzip": "~0.1.0"
+    "adm-zip": "~0.1.9"
   },
   "devDependencies": {
     "nodeunit": "~0.7.4"


### PR DESCRIPTION
I have been experiencing the problem described in issue Obvious/phantomjs#19. It is 100% reproducible on my system.

Windows 7 - 64bit, SP1
npm@1.2.11
node@v0.8.20

I've been digging at the problem and it appears that the culprit is the unzip library, or the way it's implemented in the install script. I suspect that this is being caused by a file stream not being closed before the `close` callback is being invoked. This would explain the renaming failure, because Windows will not let you rename a directory while the contents are still open for writing. But @izuzak said he checked that already, so I could be mistaken.

I cannot say for sure that the way unzip does streams is the source of the problem until I dig around in the unzip project more. However, I can say for sure that migrating from unzip to [adm-zip](https://github.com/cthackers/adm-zip) completely resolves the problem on my system.

So here is a patch that changes the zip extraction library used in the install script from unzip to adm-zip.

I have tested this patch on my system as well as run the test suite, and everything is working great. But I haven't tested it on any other operating systems so I would appreciate it if you could verify this patch on your system for me.

**A note on my code:**

I've wrapped the adm-zip extract code in a try/catch because it will `throw` errors instead of passing them around. I catch the error and pass it to the `finishIt()` function because deleting the error handing code from that function produces a very messy diff. It would probably be best to just let it throw the error and delete the error code from the `finishIt()` function.
