### PR TITLE
Changing the unzip library to adm-zip

### DIFF
--- a/install.js
+++ b/install.js
@@ -12,7 +12,7 @@ var http = require('http')
 var path = require('path')
 var url = require('url')
 var rimraf = require('rimraf').sync
-var unzip = require('unzip')
+var AdmZip = require('adm-zip')
 
 var helper = require('./lib/phantomjs')
 
@@ -132,15 +132,13 @@ function extractIt() {
   if (fileName.substr(-4) === '.zip') {
     console.log('Extracting zip contents')
 
-    var unzipStream = unzip.Extract({ path: path.dirname(downloadedFile) })
-    unzipStream.on('error', finishIt)
-    unzipStream.on('close', finishIt)
-
-    var readStream = fs.createReadStream(downloadedFile)
-    readStream.pipe(unzipStream)
-    readStream.on('error', finishIt)
-    readStream.on('close', function () { console.log('Read stream closed')})
-
+    try {
+      var zip = new AdmZip(downloadedFile);
+      zip.extractAllTo(path.dirname(downloadedFile), true);
+      finishIt();
+    } catch (err) {
+      finishIt(err);
+    }
   } else {
     console.log('Extracting tar contents (via spawned process)')
     cp.execFile('tar', ['jxf', downloadedFile], options, finishIt)

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "rimraf": "~2.0.2",
-    "unzip": "0.1.6-alpha"
+    "adm-zip": "~0.2.1"
   },
   "devDependencies": {
     "nodeunit": "~0.7.4"


### PR DESCRIPTION
We've had a number of problems with the 'unzip' library not doing
things as expected - Switching to Adm-Zip seems to (so far) have had no
issues and allows the install to work as expected
