### PR TITLE
catch(e) should be catch(err)

### DIFF
--- a/install.js
+++ b/install.js
@@ -151,7 +151,7 @@ function extractDownload(filePath, tmpPath) {
       var zip = new AdmZip(filePath)
       zip.extractAllTo(path.dirname(filePath), true)
       deferred.resolve(true)
-    } catch (e) {
+    } catch (err) {
       deferred.reject('Error extracting archive ' + err.stack)
     }
 


### PR DESCRIPTION
Stumbled into this

Phantom installation failed ReferenceError: err is not defined
    at extractDownload (../node_modules/phantomjs/install.js:155:53)
