### PR TITLE
Support release v1.9.1

### DIFF
--- a/lib/phantomjs.js
+++ b/lib/phantomjs.js
@@ -21,4 +21,4 @@ exports.path = process.platform === 'win32' ?
  * The version of phantomjs installed by this package.
  * @type {number}
  */
-exports.version = '1.9.0'
+exports.version = '1.9.1'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "phantomjs",
-  "version": "1.9.0-6",
+  "version": "1.9.1-0",
   "keywords": ["phantomjs", "headless", "webkit"],
   "description": "Headless WebKit with JS API",
   "homepage": "https://github.com/Obvious/phantomjs",


### PR DESCRIPTION
Fixes #65.

We released PhantomJS 1.9.1 about ~8 days ago. I believe this PR covers the changes necessary to support that with your Node/NPM wrapper module.

Download location (still Google Code but likely to change with the next release): https://code.google.com/p/phantomjs/downloads/list

Release announcement: https://groups.google.com/d/msg/phantomjs/K3VI5ZtGMAA/-kBTt-jSpXIJ
