### PR TITLE
Use system binary if available

### DIFF
--- a/install.js
+++ b/install.js
@@ -18,67 +18,84 @@ var mkdirp = require('mkdirp')
 var path = require('path')
 var rimraf = require('rimraf').sync
 var url = require('url')
+var which = require('which')
 
 var libPath = path.join(__dirname, 'lib', 'phantom')
 var downloadUrl = 'http://phantomjs.googlecode.com/files/phantomjs-' + helper.version + '-'
 
-if (process.platform === 'linux' && process.arch === 'x64') {
-  downloadUrl += 'linux-x86_64.tar.bz2'
-} else if (process.platform === 'linux') {
-  downloadUrl += 'linux-i686.tar.bz2'
-} else if (process.platform === 'darwin') {
-  downloadUrl += 'macosx.zip'
-} else if (process.platform === 'win32') {
-  downloadUrl += 'windows.zip'
-} else {
-  console.log('Unexpected platform or architecture:', process.platform, process.arch)
-  process.exit(1)
-}
+// let's first check whether PhantomJS is already installed..
+var deferred = kew.defer()
+which('phantomjs', deferred.makeNodeResolver());
+deferred.promise
+  // PhantomJS is installed - exit
+  .then(function() {
+    console.log('PhantomJS is already installed. Using system binary')
+    process.exit();
+  })
 
-var fileName = downloadUrl.split('/').pop()
+  // couldn't find PhantomJS binary - continue the installation
+  .fail(function() {
+    if (process.platform === 'linux' && process.arch === 'x64') {
+      downloadUrl += 'linux-x86_64.tar.bz2'
+    } else if (process.platform === 'linux') {
+      downloadUrl += 'linux-i686.tar.bz2'
+    } else if (process.platform === 'darwin') {
+      downloadUrl += 'macosx.zip'
+    } else if (process.platform === 'win32') {
+      downloadUrl += 'windows.zip'
+    } else {
+      console.log('Unexpected platform or architecture:', process.platform, process.arch)
+      process.exit(1)
+    }
 
 
-npmconf.load(function(err, conf) {
-  if (err) {
-    console.log('Error loading npm config')
-    console.error(err)
-    process.exit(1)
-    return
-  }
 
-  var tmpPath = findSuitableTempDirectory(conf)
-  var downloadedFile = path.join(tmpPath, fileName)
-  var promise = kew.resolve(true)
+    var fileName = downloadUrl.split('/').pop()
 
-  // Start the install.
-  if (!fs.existsSync(downloadedFile)) {
-    promise = promise.then(function () {
-      console.log('Downloading', downloadUrl)
-      console.log('Saving to', downloadedFile)
-      return requestBinary(getRequestOptions(conf.get('proxy')), downloadedFile)
+
+    npmconf.load(function(err, conf) {
+      if (err) {
+        console.log('Error loading npm config')
+        console.error(err)
+        process.exit(1)
+        return
+      }
+
+      var tmpPath = findSuitableTempDirectory(conf)
+      var downloadedFile = path.join(tmpPath, fileName)
+      var promise = kew.resolve(true)
+
+      // Start the install.
+      if (!fs.existsSync(downloadedFile)) {
+        promise = promise.then(function () {
+          console.log('Downloading', downloadUrl)
+          console.log('Saving to', downloadedFile)
+          return requestBinary(getRequestOptions(conf.get('proxy')), downloadedFile)
+        })
+
+      } else {
+        console.log('Download already available at', downloadedFile)
+      }
+
+      promise.then(function () {
+        return extractDownload(downloadedFile, tmpPath)
+      })
+      .then(function () {
+        return copyIntoPlace(tmpPath, libPath)
+      })
+      .then(function () {
+        return fixFilePermissions()
+      })
+      .then(function () {
+        console.log('Done. Phantomjs binary available at', helper.path)
+      })
+      .fail(function (err) {
+        console.error('Phantom installation failed', err.stack)
+        process.exit(1)
+      })
     })
 
-  } else {
-    console.log('Download already available at', downloadedFile)
-  }
-
-  promise.then(function () {
-    return extractDownload(downloadedFile, tmpPath)
   })
-  .then(function () {
-    return copyIntoPlace(tmpPath, libPath)
-  })
-  .then(function () {
-    return fixFilePermissions()
-  })
-  .then(function () {
-    console.log('Done. Phantomjs binary available at', helper.path)
-  })
-  .fail(function (err) {
-    console.error('Phantom installation failed', err.stack)
-    process.exit(1)
-  })
-})
 
 
 function findSuitableTempDirectory(npmConf) {

--- a/lib/phantomjs.js
+++ b/lib/phantomjs.js
@@ -6,15 +6,22 @@
  */
 
 var path = require('path')
+var which = require('which')
 
 
 /**
  * Where the phantom binary can be found.
  * @type {string}
  */
-exports.path = process.platform === 'win32' ?
-    path.join(__dirname, 'phantom', 'phantomjs.exe') :
-    path.join(__dirname, 'phantom', 'bin' ,'phantomjs')
+try {
+  // If already installed in system PATH
+  exports.path = which.sync('phantomjs')
+} catch(e) {
+  // If not installed in system PATH
+  exports.path = process.platform === 'win32' ?
+      path.join(__dirname, 'phantom', 'phantomjs.exe') :
+      path.join(__dirname, 'phantom', 'bin' ,'phantomjs')
+}
 
 
 /**

--- a/package.json
+++ b/package.json
@@ -1,27 +1,35 @@
 {
   "name": "phantomjs",
   "version": "1.9.1-0",
-  "keywords": ["phantomjs", "headless", "webkit"],
+  "keywords": [
+    "phantomjs",
+    "headless",
+    "webkit"
+  ],
   "description": "Headless WebKit with JS API",
   "homepage": "https://github.com/Obvious/phantomjs",
   "repository": {
     "type": "git",
     "url": "git://github.com/Obvious/phantomjs.git"
   },
-  "licenses": [ {
-    "type": "Apache 2.0",
-    "url": "http://www.apache.org/licenses/LICENSE-2.0.html"
-  } ],
+  "licenses": [
+    {
+      "type": "Apache 2.0",
+      "url": "http://www.apache.org/licenses/LICENSE-2.0.html"
+    }
+  ],
   "author": {
     "name": "Dan Pupius",
     "email": "dan@obvious.com",
     "url": "http://pupius.co.uk"
   },
-  "maintainers": [ {
-    "name": "Dan Pupius",
-    "email": "dan@obvious.com",
-    "web": "http://pupius.co.uk/"
-  } ],
+  "maintainers": [
+    {
+      "name": "Dan Pupius",
+      "email": "dan@obvious.com",
+      "web": "http://pupius.co.uk/"
+    }
+  ],
   "main": "lib/phantomjs",
   "bin": {
     "phantomjs": "./bin/phantomjs"
@@ -36,7 +44,8 @@
     "ncp": "0.4.2",
     "npmconf": "0.0.24",
     "mkdirp": "0.3.5",
-    "rimraf": "~2.0.2"
+    "rimraf": "~2.0.2",
+    "which": "~1.0.5"
   },
   "devDependencies": {
     "nodeunit": "~0.7.4"


### PR DESCRIPTION
In continue to PR #67
Only helper script changed. Now it really refers to system binary if such exists. Using `which.sync` to determine whether binary exists.
Worked for me on both FreeBSD  and CentOS with and without phantomjs installed.
However I got "PhantomJS is already installed" message in both cases for some reason, please help testing this out.
