### PR TITLE
fix install script

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "phantomjs": "./bin/phantomjs"
   },
   "scripts": {
-    "install": "node install.js",
+    "install": "install.js",
     "test": "nodeunit --reporter=minimal test/tests.js"
   },
   "dependencies": {


### PR DESCRIPTION
Fix installer under ubuntu see also `https://npmjs.org/doc/scripts.html#EXAMPLES`

there is no `node` command only `nodejs` see `/usr/share/doc/nodejs/README.Debian`

```
nodejs command
--------------

The upstream name for the Node.js interpreter command is "node".
In Debian the interpreter command has been changed to "nodejs".

This was done to prevent a namespace collision: other commands use
the same name in their upstreams, such as ax25-node from the "node"
package.

Scripts calling Node.js as a shell command must be changed to instead
use the "nodejs" command.
```
