### PR TITLE
Spoofed 'User-Agent' in header if proxy is used during install to prevent issues with corporate firewalls

### DIFF
--- a/install.js
+++ b/install.js
@@ -142,6 +142,8 @@ function getRequestOptions(proxyUrl) {
     var options = url.parse(proxyUrl)
     options.path = downloadUrl
     options.headers = { Host: url.parse(downloadUrl).host }
+    // If going through proxy, spoof the User-Agent, since may commerical proxies block blank or unknown agents in headers
+    options.headers['User-Agent'] = 'curl/7.21.4 (universal-apple-darwin11.0) libcurl/7.21.4 OpenSSL/0.9.8r zlib/1.2.5'
     // Turn basic authorization into proxy-authorization.
     if (options.auth) {
       options.headers['Proxy-Authorization'] = 'Basic ' + new Buffer(options.auth).toString('base64')


### PR DESCRIPTION
Ran into similar issues in node.js with `bower` [but could be fixed with `.bowerrc`]. Basically, with corporate firewalls (and doing research online, I'm not the only one), `http://` requests with a bad/blank/unknown `User-Agent` string are automatically rejected. As such, install never happens.

My team uses this package [as part of grunt-mocha], so installing when on the network (as opposed to getting off the network temporarily every time we wanted to `npm install` our scaffold) was an elusive, but important function. After similar issues with the latest version of `bower` [https://github.com/bower/bower/issues/698], I became intimately aware of these issues. 

Contributing this pull to help people in similar situations.

I spoofed `curl` since this was pretty generic.
