### PR TITLE
given win32, when writing location, install escapes the slashes in path

### DIFF
--- a/install.js
+++ b/install.js
@@ -124,7 +124,7 @@ whichDeferred.promise
 function writeLocationFile(location) {
   console.log('Writing location.js file')
   fs.writeFileSync(path.join(__dirname, 'lib', 'location.js'),
-      'module.exports.location = "' + location + '"')
+      'module.exports.location = "' + location.replace(/\\/g, '\\\\') + '"')
 }
 
 


### PR DESCRIPTION
On windows, the location.js is written out with only single backslash. Then the path exported from lib\phantoms.js no longer contains any of the backslash, which casues the bin\phantomjs error during spawning.

I have npm install locally with this patch on both Mac and Windows7.
