### PR TITLE
Win32 issue when phantomjs is already installed

### DIFF
--- a/install.js
+++ b/install.js
@@ -109,7 +109,7 @@ whichDeferred.promise
   })
   .then(function () {
     var location = process.platform === 'win32' ?
-        path.join(libPath, 'phantomjs.exe').replace(/\\/g, '\\\\') :
+        path.join(libPath, 'phantomjs.exe') :
         path.join(libPath, 'bin' ,'phantomjs')
     writeLocationFile(location)
     console.log('Done. Phantomjs binary available at', location)
@@ -123,6 +123,9 @@ whichDeferred.promise
 
 function writeLocationFile(location) {
   console.log('Writing location.js file')
+  if (process.platform === 'win32') {
+    location = location.replace(/\\/g, '\\\\')
+  }
   fs.writeFileSync(path.join(__dirname, 'lib', 'location.js'),
       'module.exports.location = "' + location + '"')
 }


### PR DESCRIPTION
Similar to #86 and #87, when phantomjs has already been installed globally and install.js reports `PhantomJS is already installed at...`, the path in `location.js` on win32 is not escaped properly. This fixes both code paths: fresh install and existing global installation.
