### PR TITLE
Explicitly set mode of tmp/phantomjs directory

### DIFF
--- a/install.js
+++ b/install.js
@@ -150,6 +150,9 @@ function findSuitableTempDirectory(npmConf) {
 
     try {
       mkdirp.sync(candidatePath, '0777')
+      // Make double sure we have 0777 permissions; some operating systems
+      // default umask does not allow write by default.
+      fs.chmodSync(candidatePath, '0777')
       var testFile = path.join(candidatePath, now + '.tmp')
       fs.writeFileSync(testFile, 'test')
       fs.unlinkSync(testFile)


### PR DESCRIPTION
Some operating systems (like CentOS) default umask will not allow writing to a directory created by Node with the default 777 mask.

If you don't think you want to put this here, I can perhaps see if the mkdirp project will add it there.
