### PR TITLE
Download to unique temporary file, only move once downloaded

### DIFF
--- a/install.js
+++ b/install.js
@@ -195,7 +195,8 @@ function requestBinary(requestOptions, filePath) {
 
   var count = 0
   var notifiedCount = 0
-  var outFile = fs.openSync(filePath, 'w')
+  var writePath = filePath + '-download-' + Date.now()
+  var outFile = fs.openSync(writePath, 'w')
 
   var client = http.get(requestOptions, function (response) {
     var status = response.statusCode
@@ -214,6 +215,7 @@ function requestBinary(requestOptions, filePath) {
       response.addListener('end',   function () {
         console.log('Received ' + Math.floor(count / 1024) + 'K total.')
         fs.closeSync(outFile)
+        fs.renameSync(writePath, filePath)
         deferred.resolve(filePath)
       })
 


### PR DESCRIPTION
This fixes #94 and #99 by downloading the file to a unique path and only writing it to the canonical path (shared by multiple concurrent or subsequent runs of npm install for this package) once it is fully downloaded.

Please review and let me know if you have any extra requirements around this fix, thanks!
