### PR TITLE
No absolute path will be created for phantomjs during installation

### DIFF
--- a/install.js
+++ b/install.js
@@ -116,6 +116,17 @@ whichDeferred.promise
     exit(1)
   })
 
+  
+function writeLocationFile(location) {
+  // The location.js file should only be written if a path other than the relative one was chosen.
+  console.log('Writing location.js file')
+  if (process.platform === 'win32') {
+    location = location.replace(/\\/g, '\\\\')
+  }
+  fs.writeFileSync(path.join(__dirname, 'lib', 'location.js'),
+      'module.exports.location = "' + location + '"')
+}
+
 
 function exit(code) {
   process.env.PATH = originalPath

--- a/lib/phantomjs.js
+++ b/lib/phantomjs.js
@@ -14,9 +14,15 @@ var which = require('which')
  * Where the phantom binary can be found.
  * @type {string}
  */
-exports.path = process.platform === 'win32' ?
-        path.join( __dirname, 'phantomjs', 'phantomjs.exe' ) :
-        path.join( __dirname, 'phantomjs', 'bin' ,'phantomjs')
+try {
+  // Location was written to a dedicated file during installation.
+  exports.path = require('./location').location
+} catch(e) {
+  // If there is no dedicated location given, the relative path applies.
+  exports.path = process.platform === 'win32' ?
+    path.join( __dirname, 'phantomjs', 'phantomjs.exe' ) :
+    path.join( __dirname, 'phantomjs', 'bin' ,'phantomjs')
+}
 
 
 /**


### PR DESCRIPTION
Instead of determining the location of phantomjs during installation and writing this absolute path into a separate file, this determination will simply be carried out at runtime.

This allows to check in the node module and those that depend on it (e.g. grunt-contrib-qunit) into code repositories and for use at build servers without separate installation of the modules on each individual machine.
