### PR TITLE
Extract to unique directory to avoid concurrent unpacking issues

### DIFF
--- a/install.js
+++ b/install.js
@@ -286,5 +286,8 @@ function copyIntoPlace(extractedPath, targetPath) {
     }
   }
 
-  return deferred.promise
+  // Cleanup extracted directory after it's been copied
+  return deferred.promise.then(function() {
+    return rimraf(extractedPath)
+  });
 }


### PR DESCRIPTION
When a package depends on phantomjs multiple times, typically through transitive dependencies (e.g. karma-phantomjs-launcher, casperjs, grunt-casperjs, etc.), I've been running into problems which seem to be caused by parallel processes extracting the tarball/zip to the same target directory.

This change attempts to fix these concurrency issues by ensuring that every installation process extracts the downloaded archive to a unique target directory before copying it.
