### PR TITLE
Add check for correct phantomjs binary permissions

### DIFF
--- a/lib/phantomjs.js
+++ b/lib/phantomjs.js
@@ -48,7 +48,12 @@ exports.cleanPath = function (path) {
 // install does not work correctly, likely due to some NPM step.
 if (exports.path) {
   try {
-    fs.chmodSync(exports.path, '755')
+    // avoid touching the binary if it's already got the correct permissions
+    var st = fs.statSync(exports.path);
+    var mode = st.mode | 0555;
+    if (mode !== st.mode) {
+      fs.chmodSync(exports.path, mode);
+    }
   } catch (e) {
     // Just ignore error if we don't have permission.
     // We did our best. Likely because phantomjs was already installed.


### PR DESCRIPTION
Our in-house CI system uses karma in a llnux container with an overlay filesystem, and the below chmod causes the 37M phantomjs binary to be copied into the overlay on every test (this consumed 6G of disk in just a few days for us). The fix avoids the chmod unless it's really needed.
