### PR TITLE
Correct env TEMP var for Windows

### DIFF
--- a/install.js
+++ b/install.js
@@ -143,7 +143,7 @@ function exit(code) {
 function findSuitableTempDirectory(npmConf) {
   var now = Date.now()
   var candidateTmpDirs = [
-    process.env.TMPDIR || '/tmp',
+    process.env.TMPDIR || process.env.TEMP || '/tmp',
     npmConf.get('tmp'),
     path.join(process.cwd(), 'tmp')
   ]


### PR DESCRIPTION
The Windows environment var for temp stuff is TEMP or TMP.  As coded, on Windows, findSuitableTempdirectory always created a tmp directory on the root of the current drive.  Not all users can do this, leading to possible permissions issues.  The change picks up a more correct env var.
