### PR TITLE
Do not swallow errors

### DIFF
--- a/bin/phantomjs
+++ b/bin/phantomjs
@@ -26,8 +26,15 @@ process.stdin.pipe(cp.stdin)
 
 cp.on('error', function (err) {
   console.error('Error executing phantom at', binPath)
-  throw err;
+  console.error(err.stack)
 })
+
+cp.on('exit', function(code){
+  // wait few ms for error to be printed.
+  setTimeout(function(){
+    process.exit(code);
+  }, 20);
+});
 
 process.on('SIGTERM', function() {
   cp.kill('SIGTERM')


### PR DESCRIPTION
`cp.on('exit', process.exit)` prevents `cp.on('error'` to print the error message
