### PR TITLE
Added support for multiple binaries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 /node_modules
 /lib/phantom
-/lib/location.js
+/lib/binary.json
 /tmp
 npm-debug.log

--- a/README.md
+++ b/README.md
@@ -68,6 +68,10 @@ with an additional build number that is used for revisions to the installer.
 As such `1.8.0-1` will `1.8.0-2` will both install PhantomJs 1.8 but the latter
 has newer changes to the installer.
 
+## Installing multiple binaries when keeping node_modules in project repo
+
+During runtime, this PhantomJS wrapper points at a binary specific to the platform currently running. This helps when storing `node_modules` in your repo as you will likely have to install multiple PhantomJS binaries, unless every machine you use has the same OS. If the necessary binary is not currently installed on the machine when this script is run, it will be installed in the `lib/phantom/bin` folder and then run. You will then need to commit the `node_modules` folder with the newly-added binary.
+
 A Note on PhantomJS
 -------------------
 

--- a/bin/phantomjs
+++ b/bin/phantomjs
@@ -10,27 +10,44 @@
  * {NPM_INSTALL_MARKER}
  */
 
+var fs = require('fs')
 var path = require('path')
 var spawn = require('child_process').spawn
 
-var binPath = require(path.join(__dirname, '..', 'lib', 'phantomjs')).path
+var phantomLib = require(path.join(__dirname, '..', 'lib', 'phantomjs'))
+var binPath = phantomLib.path
 
-var args = process.argv.slice(2)
+// If no binary is available for the current platform, install it then run phantom
+if (!binPath) {
+  var installProcess = spawn('node', [path.join(__dirname, '../install.js')], { stdio: 'inherit' })
+  installProcess.on('close', function () {
+    binPath = path.join(__dirname, '../lib', JSON.parse(fs.readFileSync(path.join(__dirname, '../lib/binary.json')))[process.platform])
+    fs.chmodSync(binPath, '755')
+    runPhantom()
+  })
+} else {
+  runPhantom()
+}
 
-// For Node 0.6 compatibility, pipe the streams manually, instead of using
-// `{ stdio: 'inherit' }`.
-var cp = spawn(binPath, args)
-cp.stdout.pipe(process.stdout)
-cp.stderr.pipe(process.stderr)
-process.stdin.pipe(cp.stdin)
+function runPhantom() {
+  var args = process.argv.slice(2)
 
-cp.on('error', function (err) {
-  console.error('Error executing phantom at', binPath)
-  console.error(err.stack)
-})
-cp.on('exit', process.exit)
+  // For Node 0.6 compatibility, pipe the streams manually, instead of using
+  // `{ stdio: 'inherit' }`.
+  var cp = spawn(binPath, args)
+  cp.stdout.pipe(process.stdout)
+  cp.stderr.pipe(process.stderr)
+  process.stdin.pipe(cp.stdin)
 
-process.on('SIGTERM', function() {
-  cp.kill('SIGTERM')
-  process.exit(1)
-})
+  cp.on('error', function (err) {
+    console.error('Error executing phantom at', binPath)
+    console.error(err.stack)
+  })
+  cp.on('exit', process.exit)
+
+  process.on('SIGTERM', function() {
+    cp.kill('SIGTERM')
+    process.exit(1)
+  })
+}
+

--- a/lib/phantomjs.js
+++ b/lib/phantomjs.js
@@ -15,7 +15,7 @@ var which = require('which')
  * @type {string}
  */
 try {
-  exports.path = path.resolve(__dirname, require('./location').location)
+  exports.path = path.resolve(__dirname, require('./binary')[process.platform])
 } catch(e) {
   // Must be running inside install script.
   exports.path = null


### PR DESCRIPTION
I needed to have support for multiple PhantomJS binaries because I am storing my node modules in my project repo and my tests are being run on multiple platforms.

What I did was change location.js to a binary.json file which maps a platform to a phantom binary and then during runtime check if the necessary binary is installed. If not, install it before running phantom.
