### PR TITLE
Use local tmp dir first if it exists

### DIFF
--- a/install.js
+++ b/install.js
@@ -144,9 +144,14 @@ function findSuitableTempDirectory(npmConf) {
   var now = Date.now()
   var candidateTmpDirs = [
     process.env.TMPDIR || process.env.TEMP || '/tmp',
-    npmConf.get('tmp'),
-    path.join(process.cwd(), 'tmp')
+    npmConf.get('tmp')
   ]
+  
+  // push local temp to the top of the list if it exists
+  var localTmp = path.join(process.cwd(), 'tmp')
+  if (fs.exists(localTmp)) {
+    candidateTmpDirs.unshift(localTmp)
+  }
 
   for (var i = 0; i < candidateTmpDirs.length; i++) {
     var candidatePath = path.join(candidateTmpDirs[i], 'phantomjs')


### PR DESCRIPTION
Moved around tmp path searching. The old way made it really hard to install from a local location as any of 4 other valid locations would break out of the loop and it was hard to know which one you should put the pre-downloaded file in.

Now if you have a local tmp folder it will use that first. Otherwise it falls back to the old methods.