### PR TITLE
Custom phantomjs download url.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,13 @@ Or grab the source and
 node ./install.js
 ```
 
+To use a mirror of the phantomjs binaries, set `$PHANTOMJS_CDNURL`,
+default is `http://cdn.bitbucket.org/ariya/phantomjs/downloads`
+
+```shell
+PHANTOMJS_CDNURL=http://cnpmjs.org/downloads npm install phantomjs
+```
+
 What this is really doing is just grabbing a particular "blessed" (by
 this module) version of Phantom. As new versions of Phantom are released
 and vetted, this module will be updated accordingly.

--- a/install.js
+++ b/install.js
@@ -21,7 +21,8 @@ var url = require('url')
 var util = require('util')
 var which = require('which')
 
-var downloadUrl = 'http://cdn.bitbucket.org/ariya/phantomjs/downloads/phantomjs-' + helper.version + '-'
+var cdnUrl = process.env.PHANTOMJS_CDNURL || 'http://cdn.bitbucket.org/ariya/phantomjs/downloads'
+var downloadUrl = cdnUrl + '/phantomjs-' + helper.version + '-'
 
 var originalPath = process.env.PATH
 


### PR DESCRIPTION
User can set `PHANTOMJS_CDNURL` env to download phantomjs from
other cdn. close #156 

Because `http://cdn.bitbucket.org` was block by GFW in China, so we want to download phantomjs bin from our mirror site.

e.g.:

``` bash
$ PHANTOMJS_CDNURL=http://cnpmjs.org/downloads node install

Downloading http://cnpmjs.org/downloads/phantomjs-1.9.7-macosx.zip
Saving to /var/folders/5h/x4h0t8rs6w300g_wnzbx47km0000gn/T/phantomjs/phantomjs-1.9.7-macosx.zip
Receiving...
```
