### PR TITLE
Fixing a small bug that prevents people using proxies from downloading the appropriate binary

### DIFF
--- a/install.js
+++ b/install.js
@@ -181,7 +181,8 @@ function getRequestOptions(conf) {
   var options = {
     uri: downloadUrl,
     encoding: null, // Get response as a buffer
-    followRedirect: true // The default download path redirects to a CDN URL.
+    followRedirect: true, // The default download path redirects to a CDN URL.
+    headers: []
   }
 
   var proxyUrl = conf.get('http-proxy') || conf.get('proxy')


### PR DESCRIPTION
options.header is not defined, so options.headers['Proxy-Authentication'] = ... results in a JS error. This is breaking our usage of karma-phantomjs-runner on our CI servers.
