### PR TITLE
strict-ssl flag support

### DIFF
--- a/install.js
+++ b/install.js
@@ -203,7 +203,7 @@ function getRequestOptions(conf) {
   }
 
   options.rejectUnauthorized = false;//conf.get('strict-ssl');
-  console.log('strict-ssl: ' + false));//conf.get('strict-ssl'));
+  console.log('strict-ssl: ' + false);//conf.get('strict-ssl'));
 
   return options
 }


### PR DESCRIPTION
Please add support for the npm configuration flag strict-ssl. This makes it possible to use the module behind proxies/firewalls.
