### PR TITLE
use "https-proxy" before "http-proxy" or "proxy"

### DIFF
--- a/install.js
+++ b/install.js
@@ -185,7 +185,7 @@ function getRequestOptions(conf) {
     headers: {}
   }
 
-  var proxyUrl = conf.get('http-proxy') || conf.get('proxy')
+  var proxyUrl = conf.get('https-proxy') || conf.get('http-proxy') || conf.get('proxy')
   if (proxyUrl) {
     console.log('Using proxy ' + proxyUrl)
     var proxy = url.parse(proxyUrl)


### PR DESCRIPTION
Now that we have to fetch from https, we should check for and use the https-proxy setting first.
