### PR TITLE
Fixing install.js when npm link is called.

### DIFF
--- a/install.js
+++ b/install.js
@@ -58,8 +58,16 @@ whichDeferred.promise
   .then(function (stdout) {
     var version = stdout.trim()
     if (helper.version == version) {
-      writeLocationFile(phantomPath)
-      console.log('PhantomJS is already installed at', phantomPath + '.')
+      // This makes sure that the binary isn't actually the global             
+      // npm include file, which is what gets passed to install.js             
+      // when the npm-link command is called.                                  
+      // See pull request #184: https://github.com/Medium/phantomjs/pull/184
+      if(phantomPath.indexOf(path.join('npm','phantomjs')) === -1) {
+        writeLocationFile(phantomPath);
+        console.log('PhantomJS is already installed at', phantomPath + '.');
+      } else {
+        console.log('PhantomJS is already installed.');
+      }
       exit(0)
 
     } else {


### PR DESCRIPTION
Currently npm link calls install.js but provides it with a bad path as several files that being with "phantomjs" exit in the npm root folder (for global calls). Therfore, "which" incorrectly resolves the path, giving a mistaken path to the promise. A simple check to make sure that the path isn't resolving "phantomjs" immediately after "npm" clears up the issue nicely (i.e. the path does not contain the substring "npm/phantomjs", as the correct file will always exit within node_modules of the npm folder. If the culprit substring isn't present the file writes, if it is, it doesn't.
