### PR TITLE
Use strict-ssl setting from npm configuration

### DIFF
--- a/install.js
+++ b/install.js
@@ -199,7 +199,8 @@ function getRequestOptions(conf) {
     uri: downloadUrl,
     encoding: null, // Get response as a buffer
     followRedirect: true, // The default download path redirects to a CDN URL.
-    headers: {}
+    headers: {},
+    strictSSL: conf.get('strict-ssl')
   }
 
   var proxyUrl = conf.get('https-proxy') || conf.get('http-proxy') || conf.get('proxy')


### PR DESCRIPTION
This would be nice to workaround any SSL issues, due to any corporate firewalls.
I don't think that is any security risk, since the user already set this setting in her .npmrc, being aware that the npm process (and in particular the phantomjs installer in that case) won't valid SSL anymore.
