### PR TITLE
Parsing `strict-ssl` option from npm config

### DIFF
--- a/install.js
+++ b/install.js
@@ -199,7 +199,8 @@ function getRequestOptions(conf) {
     uri: downloadUrl,
     encoding: null, // Get response as a buffer
     followRedirect: true, // The default download path redirects to a CDN URL.
-    headers: {}
+    headers: {},
+    rejectUnauthorized: !!conf.get('strict-ssl')
   }
 
   var proxyUrl = conf.get('https-proxy') || conf.get('http-proxy') || conf.get('proxy')


### PR DESCRIPTION
Additional npm config settings which can be critical for come setups.

More info about `strict-ssl` here: https://www.npmjs.org/doc/misc/npm-config.html. By default it's `true`, so won't affect regular users.
