### PR TITLE
Updating request module version

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "npmconf": "0.0.24",
     "mkdirp": "0.3.5",
     "progress": "^1.1.5",
-    "request": "2.36.0",
+    "request": "^2.40.0",
     "request-progress": "^0.3.1",
     "rimraf": "~2.2.2",
     "which": "~1.0.5"


### PR DESCRIPTION
**request@2.40.0** was released to fix a recent security issue w/ **qs**. See mikeal/request#992 and https://blog.liftsecurity.io/2014/08/06/denial-of-service-in-qs
