### PR TITLE
Bump PhantomJS version to 1.9.8

### DIFF
--- a/lib/phantomjs.js
+++ b/lib/phantomjs.js
@@ -26,7 +26,7 @@ try {
  * The version of phantomjs installed by this package.
  * @type {number}
  */
-exports.version = '1.9.7'
+exports.version = '1.9.8'
 
 
 /**


### PR DESCRIPTION
PhantomJS has a new release 1.9.8. I'm not sure if there are any other changes are needed.
