### PR TITLE
Add option to define mirror url via npm configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,16 @@ Or grab the source and
 node ./install.js
 ```
 
+What this installer is really doing is just grabbing a particular "blessed" (by
+this module) version of Phantom. As new versions of Phantom are released
+and vetted, this module will be updated accordingly.
+
+The package has been set up to fetch and run Phantom for MacOS (darwin),
+Linux based platforms (as identified by nodejs), and -- as of version 0.2.0 --
+Windows (thanks to [Domenic Denicola](https://github.com/domenic)).  If you
+spot any platform weirdnesses, let us know or send a patch.
+
+### Custom binaries url
 To use a mirror of the phantomjs binaries use npm config property `phantomjs_cdnurl`.
 Default is `https://bitbucket.org/ariya/phantomjs/downloads`.
 
@@ -29,15 +39,11 @@ Or add property into your `.mpmrc` file (https://www.npmjs.org/doc/files/npmrc.h
 phantomjs_cdnurl=http://cnpmjs.org/downloads
 ```
 
+Another option is to use PATH variable `PHANTOMJS_CDNURL`.
+```shell
+PHANTOMJS_CDNURL=http://cnpmjs.org/downloads npm install phantomjs
+```
 
-What this installer is really doing is just grabbing a particular "blessed" (by
-this module) version of Phantom. As new versions of Phantom are released
-and vetted, this module will be updated accordingly.
-
-The package has been set up to fetch and run Phantom for MacOS (darwin),
-Linux based platforms (as identified by nodejs), and -- as of version 0.2.0 --
-Windows (thanks to [Domenic Denicola](https://github.com/domenic)).  If you
-spot any platform weirdnesses, let us know or send a patch.
 
 Running
 -------

--- a/install.js
+++ b/install.js
@@ -23,7 +23,7 @@ var url = require('url')
 var util = require('util')
 var which = require('which')
 
-var cdnUrl = process.env.npm_config_phantomjs_cdnurl || 'https://bitbucket.org/ariya/phantomjs/downloads'
+var cdnUrl = process.env.npm_config_phantomjs_cdnurl || process.env.PHANTOMJS_CDNURL ||  'https://bitbucket.org/ariya/phantomjs/downloads'
 var downloadUrl = cdnUrl + '/phantomjs-' + helper.version + '-'
 
 var originalPath = process.env.PATH


### PR DESCRIPTION
Changed name of the environment variable with custom phantomjs binaries repository from `PHANTOMJS_CDNURL` to the `npm_config_phantomjs_cdnurl` . 

This name is compatible with npm configuration system and offer more ways how to define it than the system path variable only (I mention options in the updated documentation).
