### PR TITLE
Replace ncp, mkdirp, and rimraf with fs-extra for io.js support

### DIFF
--- a/install.js
+++ b/install.js
@@ -345,14 +345,4 @@ function copyIntoPlace(extractedPath, targetPath) {
     console.log('Could not find extracted file', files)
     throw new Error('Could not find extracted file')
   })
-  .then(function () {
-    // Cleanup extracted directory after it's been copied
-    console.log('Removing', extractedPath)
-    return kew.nfcall(fs.remove, extractedPath).fail(function (e) {
-      // Swallow the error quietly.
-      console.warn(e)
-      console.warn('Unable to remove temporary files at "' + extractedPath +
-          '", see https://github.com/Obvious/phantomjs/issues/108 for details.')
-    })
-  })
 }

--- a/install.js
+++ b/install.js
@@ -10,11 +10,10 @@ var requestProgress = require('request-progress')
 var progress = require('progress')
 var AdmZip = require('adm-zip')
 var cp = require('child_process')
-var fs = require('fs')
+var fs = require('fs-extra')
 var helper = require('./lib/phantomjs')
 var kew = require('kew')
 var mkdirp = require('mkdirp')
-var ncp = require('ncp')
 var npmconf = require('npmconf')
 var path = require('path')
 var request = require('request')
@@ -341,7 +340,7 @@ function copyIntoPlace(extractedPath, targetPath) {
       var file = path.join(extractedPath, files[i])
       if (fs.statSync(file).isDirectory() && file.indexOf(helper.version) != -1) {
         console.log('Copying extracted folder', file, '->', targetPath)
-        return kew.nfcall(ncp, file, targetPath)
+        return kew.nfcall(fs.move, file, targetPath)
       }
     }
 

--- a/install.js
+++ b/install.js
@@ -13,11 +13,9 @@ var cp = require('child_process')
 var fs = require('fs-extra')
 var helper = require('./lib/phantomjs')
 var kew = require('kew')
-var mkdirp = require('mkdirp')
 var npmconf = require('npmconf')
 var path = require('path')
 var request = require('request')
-var rimraf = require('rimraf')
 var url = require('url')
 var util = require('util')
 var which = require('which')
@@ -183,7 +181,7 @@ function findSuitableTempDirectory(npmConf) {
     var candidatePath = path.join(candidateTmpDirs[i], 'phantomjs')
 
     try {
-      mkdirp.sync(candidatePath, '0777')
+      fs.mkdirsSync(candidatePath, '0777')
       // Make double sure we have 0777 permissions; some operating systems
       // default umask does not allow write by default.
       fs.chmodSync(candidatePath, '0777')
@@ -299,7 +297,7 @@ function extractDownload(filePath) {
   var extractedPath = filePath + '-extract-' + Date.now()
   var options = {cwd: extractedPath}
 
-  mkdirp.sync(extractedPath, '0777')
+  fs.mkdirsSync(extractedPath, '0777')
   // Make double sure we have 0777 permissions; some operating systems
   // default umask does not allow write by default.
   fs.chmodSync(extractedPath, '0777')
@@ -333,7 +331,7 @@ function extractDownload(filePath) {
 
 function copyIntoPlace(extractedPath, targetPath) {
   console.log('Removing', targetPath)
-  return kew.nfcall(rimraf, targetPath).then(function () {
+  return kew.nfcall(fs.remove, targetPath).then(function () {
     // Look for the extracted directory, so we can rename it.
     var files = fs.readdirSync(extractedPath)
     for (var i = 0; i < files.length; i++) {
@@ -350,7 +348,7 @@ function copyIntoPlace(extractedPath, targetPath) {
   .then(function () {
     // Cleanup extracted directory after it's been copied
     console.log('Removing', extractedPath)
-    return kew.nfcall(rimraf, extractedPath).fail(function (e) {
+    return kew.nfcall(fs.remove, extractedPath).fail(function (e) {
       // Swallow the error quietly.
       console.warn(e)
       console.warn('Unable to remove temporary files at "' + extractedPath +

--- a/package.json
+++ b/package.json
@@ -42,12 +42,10 @@
     "adm-zip": "0.4.4",
     "fs-extra": "^0.15.0",
     "kew": "0.4.0",
-    "mkdirp": "0.5.0",
     "npmconf": "2.0.9",
     "progress": "1.1.8",
     "request": "2.42.0",
     "request-progress": "0.3.1",
-    "rimraf": "~2.2.8",
     "which": "~1.0.5"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -40,10 +40,10 @@
   },
   "dependencies": {
     "adm-zip": "0.4.4",
+    "fs-extra": "^0.15.0",
     "kew": "0.4.0",
-    "ncp": "~1.0.1",
-    "npmconf": "2.0.9",
     "mkdirp": "0.5.0",
+    "npmconf": "2.0.9",
     "progress": "1.1.8",
     "request": "2.42.0",
     "request-progress": "0.3.1",


### PR DESCRIPTION
Fixes issue #275 by replacing ncp, mkdirp, and rimraf with fs-extra. Have tested iojs 1.0.4 on OS X. I will add iojs testing to the travis.yml as soon as travis supports it per https://github.com/travis-ci/travis-ci/issues/3108