### PR TITLE
Append running slimer from nodejs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 /node_modules
-/lib/phantom
+/lib/slimer
 /lib/location.js
 /tmp
 npm-debug.log

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ slimerjs
 
 An NPM wrapper for [SlimerJS](http://slimerjs.org/), A scriptable browser for Web developers.
 
-This project is a find-and-replace of [phantomjs](/Medium/phantomjs).
+This project is a find-and-replace of [phantomjs](https://github.com/Medium/phantomjs).
 
 Building and Installing
 -----------------------

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 slimerjs
 =========
 
-An NPM wrapper for [SlimerJS](http://slimerjs.org/), headless webkit with JS API.
+An NPM wrapper for [SlimerJS](http://slimerjs.org/), A scriptable browser for Web developers.
+
+This project is a find-and-replace of [phantomjs](/Medium/phantomjs).
 
 Building and Installing
 -----------------------
@@ -66,7 +68,7 @@ Versioning
 The NPM package version tracks the version of SlimerJS that will be installed,
 with an additional build number that is used for revisions to the installer.
 
-As such `1.8.0-1` and `1.8.0-2` will both install SlimerJs 1.8 but the latter
+As such `0.9.1-1` and `0.9.1-2` will both install SlimerJs 0.9.1 but the latter
 has newer changes to the installer.
 
 A Note on SlimerJS
@@ -98,10 +100,7 @@ Contributing
 ------------
 
 Questions, comments, bug reports, and pull requests are all welcome.  Submit them at
-[the project on GitHub](https://github.com/Obvious/slimerjs/).  If you haven't contributed to an
-[Obvious](http://github.com/Obvious/) project before please head over to the
-[Open Source Project](https://github.com/Obvious/open-source#note-to-external-contributors) and fill
-out an OCLA (it should be pretty painless).
+[the project on GitHub](https://github.com/graingert/slimerjs/).
 
 Bug reports that include steps-to-reproduce (including code) are the
 best. Even better, make them in the form of pull requests.

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
-phantomjs
+slimerjs
 =========
 
-An NPM wrapper for [PhantomJS](http://phantomjs.org/), headless webkit with JS API.
+An NPM wrapper for [SlimerJS](http://slimerjs.org/), headless webkit with JS API.
 
 Building and Installing
 -----------------------
 
 ```shell
-npm install phantomjs
+npm install slimerjs
 ```
 
 Or grab the source and
@@ -17,10 +17,10 @@ node ./install.js
 ```
 
 What this is really doing is just grabbing a particular "blessed" (by
-this module) version of Phantom. As new versions of Phantom are released
+this module) version of Slimer. As new versions of Slimer are released
 and vetted, this module will be updated accordingly.
 
-The package has been set up to fetch and run Phantom for MacOS (darwin),
+The package has been set up to fetch and run Slimer for MacOS (darwin),
 Linux based platforms (as identified by nodejs), and -- as of version 0.2.0 --
 Windows (thanks to [Domenic Denicola](https://github.com/domenic)).  If you
 spot any platform weirdnesses, let us know or send a patch.
@@ -29,7 +29,7 @@ Running
 -------
 
 ```shell
-bin/phantomjs [phantom arguments]
+bin/slimerjs [slimer arguments]
 ```
 
 And npm will install a link to the binary in `node_modules/.bin` as
@@ -39,19 +39,19 @@ Running via node
 ----------------
 
 The package exports a `path` string that contains the path to the
-phantomjs binary/executable.
+slimerjs binary/executable.
 
 Below is an example of using this package via node.
 
 ```javascript
 var path = require('path')
 var childProcess = require('child_process')
-var phantomjs = require('phantomjs')
-var binPath = phantomjs.path
+var slimerjs = require('slimerjs')
+var binPath = slimerjs.path
 
 var childArgs = [
-  path.join(__dirname, 'phantomjs-script.js'),
-  'some other argument (passed to phantomjs script)'
+  path.join(__dirname, 'slimerjs-script.js'),
+  'some other argument (passed to slimerjs script)'
 ]
 
 childProcess.execFile(binPath, childArgs, function(err, stdout, stderr) {
@@ -63,30 +63,30 @@ childProcess.execFile(binPath, childArgs, function(err, stdout, stderr) {
 Versioning
 ----------
 
-The NPM package version tracks the version of PhantomJS that will be installed,
+The NPM package version tracks the version of SlimerJS that will be installed,
 with an additional build number that is used for revisions to the installer.
 
-As such `1.8.0-1` and `1.8.0-2` will both install PhantomJs 1.8 but the latter
+As such `1.8.0-1` and `1.8.0-2` will both install SlimerJs 1.8 but the latter
 has newer changes to the installer.
 
-A Note on PhantomJS
+A Note on SlimerJS
 -------------------
 
-PhantomJS is not a library for NodeJS.  It's a separate environment and code
-written for node is unlikely to be compatible.  In particular PhantomJS does
+SlimerJS is not a library for NodeJS.  It's a separate environment and code
+written for node is unlikely to be compatible.  In particular SlimerJS does
 not expose a Common JS package loader.
 
-This is an _NPM wrapper_ and can be used to conveniently make Phantom available
+This is an _NPM wrapper_ and can be used to conveniently make Slimer available
 It is not a Node JS wrapper.
 
-I have had reasonable experiences writing standalone Phantom scripts which I
-then drive from within a node program by spawning phantom in a child process.
+I have had reasonable experiences writing standalone Slimer scripts which I
+then drive from within a node program by spawning slimer in a child process.
 
-Read the PhantomJS FAQ for more details: http://phantomjs.org/faq.html
+Read the SlimerJS FAQ for more details: http://slimerjs.org/faq.html
 
 ### Linux Note
 
-An extra note on Linux usage, from the PhantomJS download page:
+An extra note on Linux usage, from the SlimerJS download page:
 
  > This package is built on CentOS 5.8. It should run successfully on Lucid or
  > more modern systems (including other distributions). There is no requirement
@@ -98,7 +98,7 @@ Contributing
 ------------
 
 Questions, comments, bug reports, and pull requests are all welcome.  Submit them at
-[the project on GitHub](https://github.com/Obvious/phantomjs/).  If you haven't contributed to an
+[the project on GitHub](https://github.com/Obvious/slimerjs/).  If you haven't contributed to an
 [Obvious](http://github.com/Obvious/) project before please head over to the
 [Open Source Project](https://github.com/Obvious/open-source#note-to-external-contributors) and fill
 out an OCLA (it should be pretty painless).

--- a/bin/slimerjs
+++ b/bin/slimerjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 /**
- * Script that will execute the downloaded phantomjs binary.  stdio are
+ * Script that will execute the downloaded slimerjs binary.  stdio are
  * forwarded to and from the child process.
  *
  * The following is for an ugly hack to avoid a problem where the installer
@@ -13,7 +13,7 @@
 var path = require('path')
 var spawn = require('child_process').spawn
 
-var binPath = require(path.join(__dirname, '..', 'lib', 'phantomjs')).path
+var binPath = require(path.join(__dirname, '..', 'lib', 'slimerjs')).path
 
 var args = process.argv.slice(2)
 
@@ -25,7 +25,7 @@ cp.stderr.pipe(process.stderr)
 process.stdin.pipe(cp.stdin)
 
 cp.on('error', function (err) {
-  console.error('Error executing phantom at', binPath)
+  console.error('Error executing slimer at', binPath)
   console.error(err.stack)
 })
 

--- a/install.js
+++ b/install.js
@@ -21,7 +21,7 @@ var url = require('url')
 var util = require('util')
 var which = require('which')
 
-var downloadUrl = 'http://phantomjs.googlecode.com/files/phantomjs-' + helper.version + '-'
+var downloadUrl = 'http://cdn.bitbucket.org/ariya/phantomjs/downloads/phantomjs-' + helper.version + '-'
 
 var originalPath = process.env.PATH
 

--- a/install.js
+++ b/install.js
@@ -1,7 +1,7 @@
 // Copyright 2012 The Obvious Corporation.
 
 /*
- * This simply fetches the right version of phantom for the current platform.
+ * This simply fetches the right version of slimer for the current platform.
  */
 
 'use strict'
@@ -9,7 +9,7 @@
 var AdmZip = require('adm-zip')
 var cp = require('child_process')
 var fs = require('fs')
-var helper = require('./lib/phantomjs')
+var helper = require('./lib/slimerjs')
 var http = require('http')
 var kew = require('kew')
 var ncp = require('ncp')
@@ -21,48 +21,48 @@ var url = require('url')
 var util = require('util')
 var which = require('which')
 
-var downloadUrl = 'http://cdn.bitbucket.org/ariya/phantomjs/downloads/phantomjs-' + helper.version + '-'
+var downloadUrl = 'http://download.slimerjs.org/v0.9/'+ helper.version +'/slimerjs-'+ helper.version +'-'
 
 var originalPath = process.env.PATH
 
 // NPM adds bin directories to the path, which will cause `which` to find the
-// bin for this package not the actual phantomjs bin.  Also help out people who
+// bin for this package not the actual slimerjs bin.  Also help out people who
 // put ./bin on their path
 process.env.PATH = helper.cleanPath(originalPath)
 
 var libPath = path.join(__dirname, 'lib')
-var pkgPath = path.join(libPath, 'phantom')
-var phantomPath = null
+var pkgPath = path.join(libPath, 'slimer')
+var slimerPath = null
 var tmpPath = null
 
 var whichDeferred = kew.defer()
-which('phantomjs', whichDeferred.makeNodeResolver())
+which('slimerjs', whichDeferred.makeNodeResolver())
 whichDeferred.promise
   .then(function (path) {
-    phantomPath = path
+    slimerPath = path
 
     // Horrible hack to avoid problems during global install. We check to see if
     // the file `which` found is our own bin script.
-    // See: https://github.com/Obvious/phantomjs/issues/85
-    if (/NPM_INSTALL_MARKER/.test(fs.readFileSync(phantomPath, 'utf8'))) {
+    // See: https://github.com/Obvious/slimerjs/issues/85
+    if (/NPM_INSTALL_MARKER/.test(fs.readFileSync(slimerPath, 'utf8'))) {
       console.log('Looks like an `npm install -g`; unable to check for already installed version.')
       throw new Error('Global install')
 
     } else {
       var checkVersionDeferred = kew.defer()
-      cp.execFile(phantomPath, ['--version'], checkVersionDeferred.makeNodeResolver())
+      cp.execFile(slimerPath, ['--version'], checkVersionDeferred.makeNodeResolver())
       return checkVersionDeferred.promise
     }
   })
   .then(function (stdout) {
     var version = stdout.trim()
     if (helper.version == version) {
-      writeLocationFile(phantomPath)
-      console.log('PhantomJS is already installed at', phantomPath + '.')
+      writeLocationFile(slimerPath)
+      console.log('SlimerJS is already installed at', slimerPath + '.')
       exit(0)
 
     } else {
-      console.log('PhantomJS detected, but wrong version', stdout.trim(), '@', phantomPath + '.')
+      console.log('SlimerJS detected, but wrong version', stdout.trim(), '@', slimerPath + '.')
       throw new Error('Wrong version')
     }
   })
@@ -76,15 +76,16 @@ whichDeferred.promise
   .then(function (conf) {
     tmpPath = findSuitableTempDirectory(conf)
 
+
     // Can't use a global version so start a download.
     if (process.platform === 'linux' && process.arch === 'x64') {
       downloadUrl += 'linux-x86_64.tar.bz2'
     } else if (process.platform === 'linux') {
       downloadUrl += 'linux-i686.tar.bz2'
     } else if (process.platform === 'darwin' || process.platform === 'openbsd' || process.platform === 'freebsd') {
-      downloadUrl += 'macosx.zip'
+      downloadUrl += 'mac.tar.bz2'
     } else if (process.platform === 'win32') {
-      downloadUrl += 'windows.zip'
+      downloadUrl += 'win32.zip'
     } else {
       console.error('Unexpected platform or architecture:', process.platform, process.arch)
       exit(1)
@@ -111,19 +112,19 @@ whichDeferred.promise
   })
   .then(function () {
     var location = process.platform === 'win32' ?
-        path.join(pkgPath, 'phantomjs.exe') :
-        path.join(pkgPath, 'bin' ,'phantomjs')
+        path.join(pkgPath, 'slimerjs.bat') :
+        path.join(pkgPath, 'slimerjs')
     var relativeLocation = path.relative(libPath, location)
     writeLocationFile(relativeLocation)
     
     // Ensure executable is executable by all users
     fs.chmodSync(location, '755')
     
-    console.log('Done. Phantomjs binary available at', location)
+    console.log('Done. Slimerjs binary available at', location)
     exit(0)
   })
   .fail(function (err) {
-    console.error('Phantom installation failed', err, err.stack)
+    console.error('Slimer installation failed', err, err.stack)
     exit(1)
   })
 
@@ -153,7 +154,7 @@ function findSuitableTempDirectory(npmConf) {
   ]
 
   for (var i = 0; i < candidateTmpDirs.length; i++) {
-    var candidatePath = path.join(candidateTmpDirs[i], 'phantomjs')
+    var candidatePath = path.join(candidateTmpDirs[i], 'slimerjs')
 
     try {
       mkdirp.sync(candidatePath, '0777')
@@ -170,7 +171,7 @@ function findSuitableTempDirectory(npmConf) {
   }
 
   console.error('Can not find a writable tmp directory, please report issue ' +
-      'on https://github.com/Obvious/phantomjs/issues/59 with as much ' +
+      'on https://github.com/Obvious/slimerjs/issues/59 with as much ' +
       'information as possible.')
   exit(1)
 }
@@ -303,7 +304,7 @@ function copyIntoPlace(extractedPath, targetPath) {
       return rimraf(extractedPath)
     } catch (e) {
       console.warn('Unable to remove temporary files at "' + extractedPath +
-          '", see https://github.com/Obvious/phantomjs/issues/108 for details.')
+          '", see https://github.com/Obvious/slimerjs/issues/108 for details.')
     }
   });
 }

--- a/lib/slimerjs.js
+++ b/lib/slimerjs.js
@@ -1,7 +1,7 @@
 // Copyright 2013 The Obvious Corporation.
 
 /**
- * @fileoverview Helpers made available via require('phantomjs') once package is
+ * @fileoverview Helpers made available via require('slimerjs') once package is
  * installed.
  */
 
@@ -11,7 +11,7 @@ var which = require('which')
 
 
 /**
- * Where the phantom binary can be found.
+ * Where the slimer binary can be found.
  * @type {string}
  */
 try {
@@ -23,10 +23,10 @@ try {
 
 
 /**
- * The version of phantomjs installed by this package.
+ * The version of slimerjs installed by this package.
  * @type {number}
  */
-exports.version = '1.9.7'
+exports.version = '0.9.1'
 
 
 /**
@@ -56,6 +56,6 @@ if (exports.path) {
     }
   } catch (e) {
     // Just ignore error if we don't have permission.
-    // We did our best. Likely because phantomjs was already installed.
+    // We did our best. Likely because slimerjs was already installed.
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "phantomjs",
-  "version": "1.9.7-4",
+  "version": "1.9.7-5",
   "keywords": [
     "phantomjs",
     "headless",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "phantomjs",
-  "version": "1.9.7-1",
+  "version": "1.9.7-2",
   "keywords": [
     "phantomjs",
     "headless",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "phantomjs",
-  "version": "1.9.7-0",
+  "version": "1.9.7-1",
   "keywords": [
     "phantomjs",
     "headless",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "phantomjs",
-  "version": "1.9.7-2",
+  "version": "1.9.7-3",
   "keywords": [
     "phantomjs",
     "headless",

--- a/package.json
+++ b/package.json
@@ -1,16 +1,16 @@
 {
   "name": "slimerjs",
-  "version": "1.9.7-5",
+  "version": "0.9.1",
   "keywords": [
     "slimerjs",
     "headless",
     "webkit"
   ],
   "description": "Headless WebKit with JS API",
-  "homepage": "https://github.com/Obvious/slimerjs",
+  "homepage": "https://github.com/graingert/slimerjs",
   "repository": {
     "type": "git",
-    "url": "git://github.com/Obvious/slimerjs.git"
+    "url": "git://github.com/graingert/slimerjs.git"
   },
   "licenses": [
     {
@@ -25,9 +25,9 @@
   },
   "maintainers": [
     {
-      "name": "Dan Pupius",
-      "email": "dan@obvious.com",
-      "web": "http://pupius.co.uk/"
+      "name": "Thomas Grainger",
+      "email": "tagrain@gmail.com",
+      "web": "http://graingert.co.uk/"
     }
   ],
   "main": "lib/slimerjs",

--- a/package.json
+++ b/package.json
@@ -1,16 +1,16 @@
 {
-  "name": "phantomjs",
+  "name": "slimerjs",
   "version": "1.9.7-5",
   "keywords": [
-    "phantomjs",
+    "slimerjs",
     "headless",
     "webkit"
   ],
   "description": "Headless WebKit with JS API",
-  "homepage": "https://github.com/Obvious/phantomjs",
+  "homepage": "https://github.com/Obvious/slimerjs",
   "repository": {
     "type": "git",
-    "url": "git://github.com/Obvious/phantomjs.git"
+    "url": "git://github.com/Obvious/slimerjs.git"
   },
   "licenses": [
     {
@@ -30,9 +30,9 @@
       "web": "http://pupius.co.uk/"
     }
   ],
-  "main": "lib/phantomjs",
+  "main": "lib/slimerjs",
   "bin": {
-    "phantomjs": "./bin/phantomjs"
+    "slimerjs": "./bin/slimerjs"
   },
   "scripts": {
     "install": "node install.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "slimerjs",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "keywords": [
     "slimerjs",
     "headless",
@@ -28,6 +28,11 @@
       "name": "Thomas Grainger",
       "email": "tagrain@gmail.com",
       "web": "http://graingert.co.uk/"
+    },
+    {
+      "name": "David Hanskopeit",
+      "email": "david@monkey-works.de",
+      "web": "http://www.monkey-works.de/"
     }
   ],
   "main": "lib/slimerjs",

--- a/test/exit.js
+++ b/test/exit.js
@@ -1,1 +1,1 @@
-phantom.exit(123)
+slimer.exit(123)

--- a/test/loadspeed.js
+++ b/test/loadspeed.js
@@ -1,4 +1,4 @@
-// phantomjs test script
+// slimerjs test script
 // opens url and reports time to load
 // requires an active internet connection
 var page = require('webpage').create()
@@ -8,7 +8,7 @@ var address
 
 if (system.args.length === 1) {
   console.log('Usage: loadspeed.js <some URL>')
-  phantom.exit()
+  slimer.exit()
 }
 
 t = Date.now()
@@ -21,5 +21,5 @@ page.open(address, function (status) {
     console.log('Loading time ' + t + ' msec')
   }
 
-  phantom.exit()
+  slimer.exit()
 })

--- a/test/tests.js
+++ b/test/tests.js
@@ -1,22 +1,22 @@
 /**
- * Nodeunit functional tests.  Requires internet connection to validate phantom
+ * Nodeunit functional tests.  Requires internet connection to validate slimer
  * functions correctly.
  */
 
 var childProcess = require('child_process')
 var fs = require('fs')
 var path = require('path')
-var phantomjs = require('../lib/phantomjs')
+var slimerjs = require('../lib/slimerjs')
 
 
 exports.testDownload = function (test) {
   test.expect(1)
-  test.ok(fs.existsSync(phantomjs.path), 'Binary file should have been downloaded')
+  test.ok(fs.existsSync(slimerjs.path), 'Binary file should have been downloaded')
   test.done()
 }
 
 
-exports.testPhantomExecutesTestScript = function (test) {
+exports.testSlimerExecutesTestScript = function (test) {
   test.expect(1)
 
   var childArgs = [
@@ -24,7 +24,7 @@ exports.testPhantomExecutesTestScript = function (test) {
     'http://www.google.com/'
   ]
 
-  childProcess.execFile(phantomjs.path, childArgs, function (err, stdout, stderr) {
+  childProcess.execFile(slimerjs.path, childArgs, function (err, stdout, stderr) {
     var value = (stdout.indexOf('msec') !== -1)
     test.ok(value, 'Test script should have executed and returned run time')
     test.done()
@@ -32,10 +32,10 @@ exports.testPhantomExecutesTestScript = function (test) {
 }
 
 
-exports.testPhantomExitCode = function (test) {
+exports.testSlimerExitCode = function (test) {
   test.expect(1)
-  childProcess.execFile(phantomjs.path, [path.join(__dirname, 'exit.js')], function (err, stdout, stderr) {
-    test.equals(err.code, 123, 'Exit code should be returned from phantom script')
+  childProcess.execFile(slimerjs.path, [path.join(__dirname, 'exit.js')], function (err, stdout, stderr) {
+    test.equals(err.code, 123, 'Exit code should be returned from slimer script')
     test.done()
   })
 }
@@ -45,11 +45,11 @@ exports.testBinFile = function (test) {
   test.expect(1)
 
   var binPath = process.platform === 'win32' ? 
-      path.join(__dirname, '..', 'lib', 'phantom', 'phantomjs.exe') :
-      path.join(__dirname, '..', 'bin', 'phantomjs')
+      path.join(__dirname, '..', 'lib', 'slimer', 'slimerjs.exe') :
+      path.join(__dirname, '..', 'bin', 'slimerjs')
 
   childProcess.execFile(binPath, ['--version'], function (err, stdout, stderr) {
-    test.equal(phantomjs.version, stdout.trim(), 'Version should be match')
+    test.equal(slimerjs.version, stdout.trim(), 'Version should be match')
     test.done()
   })
 }
@@ -57,10 +57,10 @@ exports.testBinFile = function (test) {
 
 exports.testCleanPath = function (test) {
   test.expect(5)
-  test.equal('/Users/dan/bin', phantomjs.cleanPath('/Users/dan/bin:./bin'))
-  test.equal('/Users/dan/bin:/usr/bin', phantomjs.cleanPath('/Users/dan/bin:./bin:/usr/bin'))
-  test.equal('/usr/bin', phantomjs.cleanPath('./bin:/usr/bin'))
-  test.equal('', phantomjs.cleanPath('./bin'))
-  test.equal('/Work/bin:/usr/bin', phantomjs.cleanPath('/Work/bin:/Work/phantomjs/node_modules/.bin:/usr/bin'))
+  test.equal('/Users/dan/bin', slimerjs.cleanPath('/Users/dan/bin:./bin'))
+  test.equal('/Users/dan/bin:/usr/bin', slimerjs.cleanPath('/Users/dan/bin:./bin:/usr/bin'))
+  test.equal('/usr/bin', slimerjs.cleanPath('./bin:/usr/bin'))
+  test.equal('', slimerjs.cleanPath('./bin'))
+  test.equal('/Work/bin:/usr/bin', slimerjs.cleanPath('/Work/bin:/Work/slimerjs/node_modules/.bin:/usr/bin'))
   test.done()
 }


### PR DESCRIPTION
From the basic doc(readme), we cannot find how to run slimerjs from the nodejs sourcecode, and after trying, I found the below line worked:
```
spawn("casperjs", ['--engine=slimerjs', scriptFilePath, reportFileName, accessingUrl]);
```
I hope you guys could append this kind of thing to readme or basic document, letting a green hand to know.