### PR TITLE
Bump up phantomjs version number to 2.0.0

### DIFF
--- a/lib/phantomjs.js
+++ b/lib/phantomjs.js
@@ -26,7 +26,7 @@ try {
  * The version of phantomjs installed by this package.
  * @type {number}
  */
-exports.version = '1.9.8'
+exports.version = '2.0.0'
 
 
 /**


### PR DESCRIPTION
Bump up the version number to avail of the [latest features](https://github.com/ariya/phantomjs/blob/master/ChangeLog#L3...L21).

I have a test suite with large number of front-end tests that employ PhantomJS through Karma-PhantomJS-Launcher. The [controllable memory cache](https://github.com/ariya/phantomjs/issues/10357) feature in the new version will resolve some of the memory leak issues that apparently a lot of the developers working on large front-end codebases are having.