### PR TITLE
close downloaded file handler priot to renaming.

### DIFF
--- a/install.js
+++ b/install.js
@@ -260,6 +260,7 @@ function requestBinary(requestOptions, filePath) {
     console.log('');
     if (!error && response.statusCode === 200) {
       fs.writeFileSync(writePath, body)
+      fs.closeSync(outFile)
       console.log('Received ' + Math.floor(body.length / 1024) + 'K total.')
       fs.renameSync(writePath, filePath)
       deferred.resolve(filePath)


### PR DESCRIPTION
In vagrant
Host windows 7 ultimate 64 bit
Guest hashicorp/precise32
tried to install inside shared folder (virtual box) via npm,
and without this line I get ETXTBSY.