### PR TITLE
Ability to specify PhantomJS version

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,12 @@ Another option is to use PATH variable `PHANTOMJS_CDNURL`.
 PHANTOMJS_CDNURL=http://cnpmjs.org/downloads npm install phantomjs
 ```
 
+### Custom PhantomJS version
+A custom version number of Phantom can be used by suppling the following CLI argument
+
+```shell
+npm install phantomjs --phantomjs_version=2.0.0
+```
 
 Running
 -------

--- a/install.js
+++ b/install.js
@@ -21,8 +21,8 @@ var util = require('util')
 var which = require('which')
 
 var cdnUrl = process.env.npm_config_phantomjs_cdnurl || process.env.PHANTOMJS_CDNURL ||  'https://bitbucket.org/ariya/phantomjs/downloads'
-var version = process.env.npm_config_phantomjs_version || process.env.PHANTOMJS_VERSION ||  helper.version
-var downloadUrl = cdnUrl + '/phantomjs-' + version + '-'
+var phantomVersion = process.env.npm_config_phantomjs_version || process.env.PHANTOMJS_VERSION ||  helper.version
+var downloadUrl = cdnUrl + '/phantomjs-' + phantomVersion + '-'
 
 var originalPath = process.env.PATH
 
@@ -82,7 +82,7 @@ whichDeferred.promise
   })
   .then(function (stdout) {
     var version = stdout.trim()
-    if (helper.version == version) {
+    if (phantomVersion == version) {
       writeLocationFile(phantomPath);
       console.log('PhantomJS is already installed at', phantomPath + '.')
       exit(0)
@@ -343,7 +343,7 @@ function copyIntoPlace(extractedPath, targetPath) {
     var files = fs.readdirSync(extractedPath)
     for (var i = 0; i < files.length; i++) {
       var file = path.join(extractedPath, files[i])
-      if (fs.statSync(file).isDirectory() && file.indexOf(helper.version) != -1) {
+      if (fs.statSync(file).isDirectory() && file.indexOf(phantomVersion) != -1) {
         console.log('Copying extracted folder', file, '->', targetPath)
         return kew.nfcall(fs.move, file, targetPath)
       }

--- a/install.js
+++ b/install.js
@@ -21,7 +21,8 @@ var util = require('util')
 var which = require('which')
 
 var cdnUrl = process.env.npm_config_phantomjs_cdnurl || process.env.PHANTOMJS_CDNURL ||  'https://bitbucket.org/ariya/phantomjs/downloads'
-var downloadUrl = cdnUrl + '/phantomjs-' + helper.version + '-'
+var version = process.env.npm_config_phantomjs_version || process.env.PHANTOMJS_VERSION ||  helper.version
+var downloadUrl = cdnUrl + '/phantomjs-' + version + '-'
 
 var originalPath = process.env.PATH
 


### PR DESCRIPTION
We needed to get v2.0.0 of Phantom in our app but having 1.9 hard coded was causing issues, so for anyone else who might want it, here is a way to get it