### PR TITLE
Add Node v0.12 and iojs to .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: node_js
 node_js:
+  - "iojs"
+  - "0.12"
   - "0.10"
   - "0.8"
 


### PR DESCRIPTION
According to CHANGELOG, phantomjs supports iojs.  https://github.com/Medium/phantomjs/releases/tag/v1.9.15

So I think phantomjs runs Test CI on iojs to be better.