### PR TITLE
Don't chmod the executable

### DIFF
--- a/install.js
+++ b/install.js
@@ -72,17 +72,6 @@ kew.resolve(true)
         path.join(pkgPath, 'phantomjs.exe') :
         path.join(pkgPath, 'bin' ,'phantomjs')
 
-    try {
-      // Ensure executable is executable by all users
-      fs.chmodSync(location, '755')
-    } catch (err) {
-      if (err.code == 'ENOENT') {
-        console.error('chmod failed: phantomjs was not successfully copied to', location)
-        exit(1)
-      }
-      throw err
-    }
-
     var relativeLocation = path.relative(libPath, location)
     writeLocationFile(relativeLocation)
 


### PR DESCRIPTION
This thrown an error when the node_modules are group writable and `npm install` is run by members of that group. Personally I find it obnoxious that someone thought that managing user's access rights for them was a good idea.