### PR TITLE
Fix path to phantomjs.exe on Windows

### DIFF
--- a/install.js
+++ b/install.js
@@ -123,7 +123,7 @@ whichDeferred.promise
   })
   .then(function () {
     var location = process.platform === 'win32' ?
-        path.join(pkgPath, 'phantomjs.exe') :
+        path.join(pkgPath, 'bin', 'phantomjs.exe') :
         path.join(pkgPath, 'bin' ,'phantomjs')
     var relativeLocation = path.relative(libPath, location)
     writeLocationFile(relativeLocation)


### PR DESCRIPTION
I was trying to install Phantom on Windows, but always had this : 
```bash
Phantom installation failed { [Error: ENOENT, no such file or directory 'D:\dev\phantomjs\lib\phantom\phantomjs.exe']
  errno: -4058,
  code: 'ENOENT',
  path: 'D:\\dev\\phantomjs\\lib\\phantom\\phantomjs.exe',
  syscall: 'chmod' } Error: ENOENT, no such file or directory 'D:\dev\phantomjs\lib\phantom\phantomjs.exe'
    at Error (native)
    at Object.fs.chmodSync (evalmachine.<anonymous>:948:18)
    at Object.chmodSync (D:\dev\phantomjs\node_modules\graceful-fs\polyfills.js:141:17)
    at Promise._successFn (D:\dev\phantomjs\install.js:133:8)
    at Promise._call (D:\dev\phantomjs\node_modules\kew\kew.js:373:13)
    at Promise._withInput (D:\dev\phantomjs\node_modules\kew\kew.js:333:25)
    at Promise.resolve (D:\dev\phantomjs\node_modules\kew\kew.js:105:27)
    at resolver (D:\dev\phantomjs\node_modules\kew\kew.js:409:17)
    at next (D:\dev\phantomjs\node_modules\rimraf\rimraf.js:72:7)
    at FSReqWrap.CB [as oncomplete] (D:\dev\phantomjs\node_modules\rimraf\rimraf.js:108:9)
```
node v0.12.5
npm  v3.5.0

This fixes the installation on Windows.
Let me know if it breaks anything else.