### PR TITLE
Update PhantomJS to 2.1.1, remove 2.0 warning in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,25 +209,6 @@ conflict. This is a non-portable change, and we do not try to support this. The
 recommends that you run `apt-get install nodejs-legacy` to symlink `node` to `nodejs` 
 on those platforms, or many NodeJS programs won't work properly.
 
-##### The latest version of this package installs PhantomJS 1.9.8. When is PhantomJS 2.0 coming?
-
-In January 2015, the PhantomJS project released PhantomJS 2.0 with statically
-compiled Windows binaries.
-
-They were not able to create statically-compiled binaries for Linux or OSX 9+.
-
-This put us in a difficult position. The whole reason this NPM installer exists
-is to provide a portable, cross-platform installation process for
-PhantomJS. Without static binaries, we can't support PhantomJS 2.0.
-
-If you work on a project that does not need cross-platform installation
-(for example, if your users can compile and install phantomjs themselves on PATH),
-then there is no good reason to depend on this package. You should call phantomjs
-directly with `child_process.spawn`.
-
-The core PhantomJS team is hard at work trying to producing static binaries,
-but there's currently no timeline.
-
 Contributing
 ------------
 

--- a/lib/phantomjs.js
+++ b/lib/phantomjs.js
@@ -26,7 +26,7 @@ try {
  * The version of phantomjs installed by this package.
  * @type {number}
  */
-exports.version = '1.9.8'
+exports.version = '2.1.1'
 
 
 /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "phantomjs",
-  "version": "1.9.19",
+  "version": "2.1.1",
   "keywords": [
     "phantomjs",
     "headless",
@@ -42,7 +42,7 @@
     "adm-zip": "0.4.4",
     "fs-extra": "~0.23.1",
     "kew": "0.4.0",
-    "md5": "~2.0.0",  
+    "md5": "~2.0.0",
     "npmconf": "2.1.1",
     "progress": "1.1.8",
     "request": "2.42.0",


### PR DESCRIPTION
Fixes #437