### PR TITLE
Request now handles the proxy stuff

### DIFF
--- a/install.js
+++ b/install.js
@@ -161,23 +161,6 @@ function getRequestOptions() {
     strictSSL: strictSSL
   }
 
-  var proxyUrl = process.env.npm_config_https_proxy ||
-      process.env.npm_config_http_proxy ||
-      process.env.npm_config_proxy
-  if (proxyUrl) {
-
-    // Print using proxy
-    var proxy = url.parse(proxyUrl)
-    if (proxy.auth) {
-      // Mask password
-      proxy.auth = proxy.auth.replace(/:.*$/, ':******')
-    }
-    console.log('Using proxy ' + url.format(proxy))
-
-    // Enable proxy
-    options.proxy = proxyUrl
-  }
-
   // Use the user-agent string from the npm config
   options.headers['User-Agent'] = process.env.npm_config_user_agent
 


### PR DESCRIPTION
Request now properly handles all the proxy configuration, and properly respects the `no_proxy` environment variable.  By setting the `proxy` value on the `request` object, we're telling request to bypass its own proxy configuration logic, and the no_proxy variable gets ignored. 