### PR TITLE
Make sure the fist item in the ca array actually contains a certificate

### DIFF
--- a/install.js
+++ b/install.js
@@ -187,6 +187,14 @@ function getRequestOptions() {
     try {
       ca = fs.readFileSync(process.env.npm_config_cafile, {encoding: 'utf8'})
         .split(/\n(?=-----BEGIN CERTIFICATE-----)/g)
+
+      // Comments at the beginning of the file result in the first
+      // item not containing a certificate - in this case the
+      // download will fail
+      if (ca.length > 0 && !/-----BEGIN CERTIFICATE-----/.test(ca[0])) {
+        ca.shift()
+      }
+
     } catch (e) {
       console.error('Could not read cafile', process.env.npm_config_cafile, e)
     }


### PR DESCRIPTION
When using a cafile option with npm, the file might contain comments (like when you base it off of the [main node root certs file](https://github.com/nodejs/node/blob/master/src/node_root_certs.h))

In this case, the first entry in the ca option from the split isn't a valid cert, and the whole thing is ignored.

I really wish there was an option to make node/npm use the system certs...