### PR TITLE
fix: migrate relative path to absolute path before calling into shell

### DIFF
--- a/install.js
+++ b/install.js
@@ -296,7 +296,7 @@ function extractDownload(filePath) {
 
   } else {
     console.log('Extracting tar contents (via spawned process)')
-    cp.execFile('tar', ['jxf', filePath], options, function (err) {
+    cp.execFile('tar', ['jxf', path.resolve(filePath)], options, function (err) {
       if (err) {
         console.error('Error extracting archive')
         deferred.reject(err)


### PR DESCRIPTION
This simple fix allows us to support relative paths on linux distributions. 

Resolves #467 

This error occurs when setting a relative temp dir environment variable. Tested on OSX/Debian/Ubuntu Node 0.12 & 0.5.