### PR TITLE
Improve MD5 calculation

### DIFF
--- a/install.js
+++ b/install.js
@@ -11,9 +11,9 @@ var progress = require('progress')
 var AdmZip = require('adm-zip')
 var cp = require('child_process')
 var fs = require('fs-extra')
+var hasha = require('hasha')
 var helper = require('./lib/phantomjs')
 var kew = require('kew')
-var md5 = require('md5')
 var path = require('path')
 var request = require('request')
 var url = require('url')
@@ -475,8 +475,8 @@ function downloadPhantomjs() {
  * @return {Promise.<boolean>}
  */
 function verifyChecksum(fileName, checksum) {
-  return kew.nfcall(fs.readFile, fileName).then(function (buffer) {
-    var result = checksum == md5(buffer)
+  return kew.resolve(hasha.fromFile(fileName, {algorithm: 'md5'})).then(function (hash) {
+    var result = checksum == hash
     if (result) {
       console.log('Verified checksum of previously downloaded file')
     } else {

--- a/package.json
+++ b/package.json
@@ -41,8 +41,8 @@
   "dependencies": {
     "adm-zip": "~0.4.7",
     "fs-extra": "~0.26.4",
+    "hasha": "^2.2.0",
     "kew": "~0.7.0",
-    "md5": "~2.0.0",
     "progress": "~1.1.8",
     "request": "~2.67.0",
     "request-progress": "~2.0.1",


### PR DESCRIPTION
This fixes #462.

Performance also increased significantly when reusing a previously downloaded release (streaming approach + native MD5 implementation).
On my machine, `install.js` reduced its execution time by 60% (from 8 to 3 seconds).