### PR TITLE
Refined reusing strategy for phantomjs binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ PHANTOMJS_CDNURL=http://cnpmjs.org/downloads npm install phantomjs
 
 If you plan to install phantomjs many times on a single machine, you can
 install the `phantomjs` binary on PATH. The installer will automatically detect
-and use that for non-global installs.
+and use that for non-global installs. A global npm installation of phantomjs-prebuilt will never be reused for local installs.
 
 Cross-Platform Repositories
 ---------------------------


### PR DESCRIPTION
The documentation that the installer detects phantomjs on the PATH was a bit unclear for me, since a global installation by npm is on the PATH, too.

Original issue https://github.com/Medium/phantomjs/issues/482