### PR TITLE
Fixes #477 by passing CA options directly.

### DIFF
--- a/install.js
+++ b/install.js
@@ -205,6 +205,7 @@ function getRequestOptions() {
     options.agentOptions = {
       ca: ca
     }
+    options.ca = ca
   }
 
   return options


### PR DESCRIPTION
This fixes a recent regression in support for proxy servers combined with custom SSL certificates. See #477.