### PR TITLE
Get temporary dir using built-in funtion

### DIFF
--- a/install.js
+++ b/install.js
@@ -10,6 +10,7 @@ var requestProgress = require('request-progress')
 var progress = require('progress')
 var extractZip = require('extract-zip')
 var cp = require('child_process')
+var os = require('os')
 var fs = require('fs-extra')
 var helper = require('./lib/phantomjs')
 var kew = require('kew')
@@ -104,7 +105,7 @@ function exit(code) {
 function findSuitableTempDirectory() {
   var now = Date.now()
   var candidateTmpDirs = [
-    process.env.TMPDIR || process.env.TEMP || process.env.npm_config_tmp,
+    os.tmpdir(),
     '/tmp',
     path.join(process.cwd(), 'tmp')
   ]


### PR DESCRIPTION
I run `npm install phantomjs-prebuilt` and got the following error:
```
Phantom installation failed [TypeError: Path must be a string. Received undefined] TypeError: Path must be a string. Received undefined
    at assertPath (path.js:7:11)
    at Object.join (path.js:1251:7)
    at findSuitableTempDirectory (/node_modules/phantomjs-prebuilt/install.js:127:30)
    at /node_modules/phantomjs-prebuilt/install.js:476:19
    at nextTickCallback (/node_modules/phantomjs-prebuilt/kew.js:47:28)
    at _combinedTickCallback (node.js:376:9)
    at process._tickCallback (node.js:407:11)
/usr/local/lib/node_modules/ied/bin/cmd.js:57
          throw err
```

That happened because I don't have any of [these environment variables](https://github.com/Medium/phantomjs/blob/master/install.js#L107) set. Also Node.js has handy [`os.tmpdir()`](https://nodejs.org/dist/latest-v4.x/docs/api/os.html#os_os_tmpdir) method for it, and it works well for me.