### PR TITLE
Lint all code, not just tests, and fix issues.

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,2 @@
+lib/phantom
+lib/location.js

--- a/.eslintrc
+++ b/.eslintrc
@@ -15,7 +15,8 @@
         ]
     },
     "env": {
-        "node": true
+        "node": true,
+        "phantomjs": true
     },
     "extends": "eslint:recommended"
 }

--- a/lib/phantomjs.js
+++ b/lib/phantomjs.js
@@ -51,10 +51,10 @@ exports.cleanPath = function (path) {
 if (exports.path) {
   try {
     // avoid touching the binary if it's already got the correct permissions
-    var st = fs.statSync(exports.path);
-    var mode = st.mode | parseInt("0555", 8);
+    var st = fs.statSync(exports.path)
+    var mode = st.mode | parseInt('0555', 8)
     if (mode !== st.mode) {
-      fs.chmodSync(exports.path, mode);
+      fs.chmodSync(exports.path, mode)
     }
   } catch (e) {
     // Just ignore error if we don't have permission.

--- a/package.json
+++ b/package.json
@@ -36,20 +36,20 @@
   },
   "scripts": {
     "install": "node install.js",
-    "test": "nodeunit --reporter=minimal test/tests.js && eslint install.js"
+    "test": "nodeunit --reporter=minimal test/tests.js && eslint ."
   },
   "dependencies": {
     "extract-zip": "~1.5.0",
-    "fs-extra": "~0.26.4",
+    "fs-extra": "~0.26.7",
     "hasha": "^2.2.0",
     "kew": "~0.7.0",
     "progress": "~1.1.8",
-    "request": "~2.67.0",
+    "request": "~2.71.0",
     "request-progress": "~2.0.1",
-    "which": "~1.2.2"
+    "which": "~1.2.4"
   },
   "devDependencies": {
-    "eslint": "1.10.3",
+    "eslint": "2.7.0",
     "nodeunit": "0.9.1"
   }
 }

--- a/test/tests.js
+++ b/test/tests.js
@@ -6,7 +6,6 @@
 var childProcess = require('child_process')
 var fs = require('fs')
 var path = require('path')
-var location = require('../lib/location')
 var phantomjs = require('../lib/phantomjs')
 var util = require('../lib/util')
 
@@ -26,7 +25,7 @@ exports.testPhantomExecutesTestScript = function (test) {
     'http://www.google.com/'
   ]
 
-  childProcess.execFile(phantomjs.path, childArgs, function (err, stdout, stderr) {
+  childProcess.execFile(phantomjs.path, childArgs, function (err, stdout) {
     var value = (stdout.indexOf('msec') !== -1)
     test.ok(value, 'Test script should have executed and returned run time')
     test.done()
@@ -36,7 +35,7 @@ exports.testPhantomExecutesTestScript = function (test) {
 
 exports.testPhantomExitCode = function (test) {
   test.expect(1)
-  childProcess.execFile(phantomjs.path, [path.join(__dirname, 'exit.js')], function (err, stdout, stderr) {
+  childProcess.execFile(phantomjs.path, [path.join(__dirname, 'exit.js')], function (err) {
     test.equals(err.code, 123, 'Exit code should be returned from phantom script')
     test.done()
   })
@@ -50,7 +49,7 @@ exports.testBinFile = function (test) {
       path.join(__dirname, '..', 'lib', 'phantom', 'phantomjs.exe') :
       path.join(__dirname, '..', 'bin', 'phantomjs')
 
-  childProcess.execFile(binPath, ['--version'], function (err, stdout, stderr) {
+  childProcess.execFile(binPath, ['--version'], function (err, stdout) {
     test.equal(phantomjs.version, stdout.trim(), 'Version should be match')
     test.done()
   })


### PR DESCRIPTION
 This bumps `eslint` and `request`.  The other version bumps are just to bump explicitly.