### PR TITLE
Remove trailing slash from default cdn url

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -11,7 +11,7 @@ var helper = require('./phantomjs')
 var kew = require('kew')
 var path = require('path')
 
-var DEFAULT_CDN = 'https://github.com/Medium/phantomjs/releases/download/v2.1.1/'
+var DEFAULT_CDN = 'https://github.com/Medium/phantomjs/releases/download/v2.1.1'
 var libPath = __dirname
 
 /**


### PR DESCRIPTION
I just got a bug ticket in my module because this string concatenation generates a url with two consecutive slashes.
e.g.
`https://github.com/Medium/phantomjs/releases/download/v2.1.1//phantomjs-2.1.1-linux-x86_64.tar.bz2`

While this is currently not a problem, it will break once github changes their routing behavior.
Most likely this will never happen. :smile: 

I wouldn't change the joining behavior. Maybe somebody really wants to use two slashes :)