### PR TITLE
Update fs-extra to version 0.30.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   },
   "dependencies": {
     "extract-zip": "~1.5.0",
-    "fs-extra": "~0.26.4",
+    "fs-extra": "~0.30.0",
     "hasha": "^2.2.0",
     "kew": "~0.7.0",
     "progress": "~1.1.8",


### PR DESCRIPTION
Fixes failing Travis CI runs in openlayers/ol3#5327.

Would be great if this could be merged and a new release could be published. Thanks!