### PR TITLE
bundle dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,5 +51,15 @@
   "devDependencies": {
     "eslint": "2.7.0",
     "nodeunit": "0.9.1"
-  }
+  },
+  "bundledDependencies": [
+    "extract-zip",
+    "fs-extra",
+    "hasha",
+    "kew",
+    "progress",
+    "request",
+    "request-progress",
+    "which"
+  ]
 }


### PR DESCRIPTION
Bundling the dependencies ensures that they are always present when npm
runs a package's lifecycle scripts. This is necessary to get any sort of
consistency in behaviour when using dependencies in install scripts
because the installation order in npm@2 is non-deterministic and that is
the version of npm that ships with the current LTS releases of Node.

This should address #581, #580, #578, #553, #584

May also help with #302, #556, #555, which aren't clear what their root
causes are due to lack of detail.