### PR TITLE
fix issue with tryPhantomjsInLib on Elastic Beanstalk

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -16,10 +16,10 @@ var libPath = __dirname
 
 /**
  * Given a lib/location file of a PhantomJS previously installed with NPM,
- * try to link the binary to this lib/location.
- * @return {Promise<boolean>} True on success
+ * is there a valid PhantomJS binary at this lib/location.
+ * @return {Promise<string>} resolved location of phantomjs binary on success
  */
-function maybeLinkLibModule(libPath) {
+function findValidPhantomJsBinary(libPath) {
   return kew.fcall(function () {
     var libModule = require(libPath)
     if (libModule.location &&
@@ -29,9 +29,7 @@ function maybeLinkLibModule(libPath) {
       if (fs.statSync(resolvedLocation)) {
         return checkPhantomjsVersion(resolvedLocation).then(function (matches) {
           if (matches) {
-            writeLocationFile(resolvedLocation)
-            console.log('PhantomJS linked at', resolvedLocation)
-            return kew.resolve(true)
+            return kew.resolve(resolvedLocation)
           }
         })
       }
@@ -157,7 +155,7 @@ module.exports = {
   getDownloadSpec: getDownloadSpec,
   getTargetPlatform: getTargetPlatform,
   getTargetArch: getTargetArch,
-  maybeLinkLibModule: maybeLinkLibModule,
+  findValidPhantomJsBinary: findValidPhantomJsBinary,
   verifyChecksum: verifyChecksum,
   writeLocationFile: writeLocationFile
 }

--- a/test/tests.js
+++ b/test/tests.js
@@ -68,8 +68,8 @@ exports.testCleanPath = function (test) {
 
 exports.testBogusReinstallLocation = function (test) {
   util.findValidPhantomJsBinary('./blargh')
-  .then(function (success) {
-    test.ok(!success, 'Expected link to fail')
+  .then(function (binaryLocation) {
+    test.ok(!binaryLocation, 'Expected link to fail')
     test.done()
   })
 }
@@ -84,8 +84,8 @@ exports.testSuccessfulReinstallLocation = function (test) {
 
 exports.testBogusVerifyChecksum = function (test) {
   util.verifyChecksum(path.resolve(__dirname, './exit.js'), 'blargh')
-  .then(function (binaryLocation) {
-    test.ok(!binaryLocation, 'Expected checksum to fail')
+  .then(function (success) {
+    test.ok(!success, 'Expected checksum to fail')
     test.done()
   })
 }

--- a/test/tests.js
+++ b/test/tests.js
@@ -67,7 +67,7 @@ exports.testCleanPath = function (test) {
 }
 
 exports.testBogusReinstallLocation = function (test) {
-  util.maybeLinkLibModule('./blargh')
+  util.findValidPhantomJsBinary('./blargh')
   .then(function (success) {
     test.ok(!success, 'Expected link to fail')
     test.done()
@@ -75,17 +75,17 @@ exports.testBogusReinstallLocation = function (test) {
 }
 
 exports.testSuccessfulReinstallLocation = function (test) {
-  util.maybeLinkLibModule(path.resolve(__dirname, '../lib/location'))
-  .then(function (success) {
-    test.ok(success, 'Expected link to succeed')
+  util.findValidPhantomJsBinary(path.resolve(__dirname, '../lib/location'))
+  .then(function (binaryLocation) {
+    test.ok(binaryLocation, 'Expected link to succeed')
     test.done()
   })
 }
 
 exports.testBogusVerifyChecksum = function (test) {
   util.verifyChecksum(path.resolve(__dirname, './exit.js'), 'blargh')
-  .then(function (success) {
-    test.ok(!success, 'Expected checksum to fail')
+  .then(function (binaryLocation) {
+    test.ok(!binaryLocation, 'Expected checksum to fail')
     test.done()
   })
 }


### PR DESCRIPTION
In v2.1.7, `tryPhantomjsInLib` wouldn't overwrite `location.js` if phantomjs was found

In v2.1.8, `tryPhantomjsInLib` would overwrite `location.js`with an absolute location if phantomjs was found

This breaks Elastic Beanstalk because they put your app in `/tmp/deployment`, run `npm install` and `npm rebuild`, then move your app to `/var/app/current`.

The `npm rebuild` was causing `location.js` to have an absolute path as the location, which was no longer valid once the app was moved to `/var/app/current` instead of `/tmp/deployment`.

The change I made should preserve some of the code cleanup by conditionally overwriting `location.js` if `findValidPhantomJsBinary` returns a valid path.

Please bump the patch version after this is merged since it's a breaking change affecting all current Elastic Beanstalk deploys :)

Thanks for your work on this repo!