### PR TITLE
implement automatic fallback for cdn urls

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -11,7 +11,6 @@ var helper = require('./phantomjs')
 var kew = require('kew')
 var path = require('path')
 
-var DEFAULT_CDN = 'https://github.com/Medium/phantomjs/releases/download/v2.1.1'
 var libPath = __dirname
 
 /**
@@ -88,10 +87,7 @@ function writeLocationFile(location) {
  * @return {?{url: string, checksum: string}} Get the download URL and expected
  *     SHA-256 checksum for phantomjs.  May return null if no download url exists.
  */
-function getDownloadSpec() {
-  var cdnUrl = process.env.npm_config_phantomjs_cdnurl ||
-      process.env.PHANTOMJS_CDNURL ||
-      DEFAULT_CDN
+function getDownloadSpec(cdnUrl) {
   var downloadUrl = cdnUrl + '/phantomjs-' + helper.version + '-'
   var checksum = ''
 


### PR DESCRIPTION
fixes https://github.com/Medium/phantomjs/issues/595

Here's example output when you provide a faulty cdn:

```bash
$ PHANTOMJS_CDNURL=http://foobar.com node install.js 
PhantomJS not found on PATH
Downloading http://foobar.com/phantomjs-2.1.1-macosx.zip
Saving to /var/folders/lb/v0m255j93wl31f312glkrkqw0000gn/T/phantomjs/phantomjs-2.1.1-macosx.zip
Receiving...

Error requesting archive.
Status: 404
Request options: {
  "uri": "http://foobar.com/phantomjs-2.1.1-macosx.zip",
  "encoding": null,
  "followRedirect": true,
  "headers": {},
  "strictSSL": false
}
Response headers: {
  "server": "nginx/1.10.1",
  "date": "Mon, 08 Aug 2016 16:21:52 GMT",
  "content-type": "text/html",
  "transfer-encoding": "chunked",
  "connection": "close",
  "accept-ranges": "bytes",
  "vary": "Accept-Encoding"
}
Make sure your network and proxy settings are correct.

If you continue to have issues, please report this full log at https://github.com/Medium/phantomjs
Something unexpected happened, please report this full log at https://github.com/Medium/phantomjs
Downloading https://github.com/Medium/phantomjs/releases/download/v2.1.1/phantomjs-2.1.1-macosx.zip
Saving to /var/folders/lb/v0m255j93wl31f312glkrkqw0000gn/T/phantomjs/phantomjs-2.1.1-macosx.zip
Receiving...
  [==============================----------] 74%
Received 16746K total.
Extracting zip contents
Removing /Users/julian/dev/medium/phantomjs/lib/phantom
Copying extracted folder /var/folders/lb/v0m255j93wl31f312glkrkqw0000gn/T/phantomjs/phantomjs-2.1.1-macosx.zip-extract-1470673319245/phantomjs-2.1.1-macosx -> /Users/julian/dev/medium/phantomjs/lib/phantom
Writing location.js file
Done. Phantomjs binary available at /Users/julian/dev/medium/phantomjs/lib/phantom/bin/phantomjs
```