### PR TITLE
Prevent replacement of global.Promise in node v4

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "test": "nodeunit --reporter=minimal test/tests.js && eslint ."
   },
   "dependencies": {
-    "es6-promise": "~3.2.1",
+    "es6-promise": "~4.0.3",
     "extract-zip": "~1.5.0",
     "fs-extra": "~0.30.0",
     "hasha": "~2.2.0",


### PR DESCRIPTION
Currently by requiring `phantomjs-prebuilt`, the original Promise is replaced by the `es6-promise` module.
This has been fixed in es6-promise v4.0.3 and we should incorporate it.

How to reproduce the current behavior?
```
$ nvm use 4
$ node
> console.log(Promise)
[Function: Promise]

> require('phantomjs-prebuilt')

> console.log(Promise)
{ [Function: lib$es6$promise$promise$$Promise]
  all: [Function: lib$es6$promise$promise$all$$all],
  race: [Function: lib$es6$promise$promise$race$$race],
  resolve: [Function: lib$es6$promise$promise$resolve$$resolve],
  reject: [Function: lib$es6$promise$promise$reject$$reject],
  _setScheduler: [Function: lib$es6$promise$asap$$setScheduler],
  _setAsap: [Function: lib$es6$promise$asap$$setAsap],
  _asap: [Function: asap] }
```