### PR TITLE
Exit with non-zero code if phantomjs was killed

### DIFF
--- a/bin/phantomjs
+++ b/bin/phantomjs
@@ -29,10 +29,10 @@ cp.on('error', function (err) {
   console.error(err.stack)
 })
 
-cp.on('exit', function(code){
+cp.on('exit', function(code, signal){
   // Wait few ms for error to be printed.
   setTimeout(function(){
-    process.exit(code)
+    process.exit(signal ? 1 : code)
   }, 20)
 });
 


### PR DESCRIPTION
When phantomjs exits with message
```
PhantomJS has crashed. Please read the bug reporting guide at
<http://phantomjs.org/bug-reporting.html> and file a bug report.
```
wrapper script exits with status = 0. It's incorrect, so I've added check second parameter of 'exit' event.