### PR TITLE
Update to PhantomJS 2.5.0-beta (missing i686 build)

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,8 +119,8 @@ cache:
     - travis_phantomjs
 
 before_install:
-  # Upgrade PhantomJS to v2.1.1.
-  - "export PHANTOMJS_VERSION=2.1.1"
+  # Upgrade PhantomJS to v2.5.0-beta.
+  - "export PHANTOMJS_VERSION=2.5.0-beta"
   - "export PATH=$PWD/travis_phantomjs/phantomjs-$PHANTOMJS_VERSION-linux-x86_64/bin:$PATH"
   - "if [ $(phantomjs --version) != $PHANTOMJS_VERSION ]; then rm -rf $PWD/travis_phantomjs; mkdir -p $PWD/travis_phantomjs; fi"
   - "if [ $(phantomjs --version) != $PHANTOMJS_VERSION ]; then wget https://github.com/Medium/phantomjs/releases/download/v$PHANTOMJS_VERSION/phantomjs-$PHANTOMJS_VERSION-linux-x86_64.tar.bz2 -O $PWD/travis_phantomjs/phantomjs-$PHANTOMJS_VERSION-linux-x86_64.tar.bz2; fi"

--- a/lib/phantomjs.js
+++ b/lib/phantomjs.js
@@ -30,7 +30,7 @@ try {
  * The version of phantomjs installed by this package.
  * @type {number}
  */
-exports.version = '2.1.1'
+exports.version = '2.5.0-beta'
 
 
 /**

--- a/lib/util.js
+++ b/lib/util.js
@@ -98,17 +98,17 @@ function getDownloadSpec() {
   var platform = getTargetPlatform()
   var arch = getTargetArch()
   if (platform === 'linux' && arch === 'x64') {
-    downloadUrl += 'linux-x86_64.tar.bz2'
-    checksum = '86dd9a4bf4aee45f1a84c9f61cf1947c1d6dce9b9e8d2a907105da7852460d2f'
+    downloadUrl += 'linux-x86_64.tar.gz'
+    checksum = 'b478bb44e7a77468683a615bda082716d76e99dc17ebbc005d31d06b6715429e'
   } else if (platform === 'linux' && arch == 'ia32') {
     downloadUrl += 'linux-i686.tar.bz2'
     checksum = '80e03cfeb22cc4dfe4e73b68ab81c9fdd7c78968cfd5358e6af33960464f15e3'
   } else if (platform === 'darwin') {
     downloadUrl += 'macosx.zip'
-    checksum = '538cf488219ab27e309eafc629e2bcee9976990fe90b1ec334f541779150f8c1'
+    checksum = '8183eaaac1bf73edbe2414870ffa4b6262b42ab97d3f252cee073746ca272acc'
   } else if (platform === 'win32') {
     downloadUrl += 'windows.zip'
-    checksum = 'd9fb05623d6b26d3654d008eab3adafd1f6350433dfd16138c46161f42c7dcc8'
+    checksum = '3e0d684e7564862cbf43e38b9e29dd087052de19d76c525d6f08c37d211a4381'
   } else {
     return null
   }

--- a/lib/util.js
+++ b/lib/util.js
@@ -11,7 +11,7 @@ var helper = require('./phantomjs')
 var kew = require('kew')
 var path = require('path')
 
-var DEFAULT_CDN = 'https://github.com/Medium/phantomjs/releases/download/v2.1.1'
+var DEFAULT_CDN = 'https://github.com/Medium/phantomjs/releases/download/v2.5.0-beta'
 var libPath = __dirname
 
 /**


### PR DESCRIPTION
This should fix #663.

Currently there is no i686 build and the build instructions for phantomjs are very out of date so I can not build it myself.

All builds were taken from https://bitbucket.org/ariya/phantomjs/downloads
