### PR TITLE
Restrict to x86 architectures

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,5 +53,6 @@
     "eslint": "2.7.0",
     "nodeunit": "0.9.1",
     "webdriverio": "~4.2.3"
-  }
+  },
+  "cpu": ["x64", "ia32"]
 }


### PR DESCRIPTION
Binaries are available only for x86 architectures, list this in metadata
to avoid unclear installation failures on ARM and other platforms.