### PR TITLE
Bump extract-zip version

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   },
   "dependencies": {
     "es6-promise": "~4.0.3",
-    "extract-zip": "~1.5.0",
+    "extract-zip": "~1.6.0",
     "fs-extra": "~1.0.0",
     "hasha": "~2.2.0",
     "kew": "~0.7.0",


### PR DESCRIPTION
This bump allows for a future release of extract-zip, that in turn pulls in a newer future release of concat-stream to mitigate [a possible memory disclosure vulnerability](https://snyk.io/vuln/npm:concat-stream:20160901). extract-zip is already at 1.6.0 so this will not happen without this bump.