### PR TITLE
cleanPath not working for all cases

### DIFF
--- a/lib/phantomjs.js
+++ b/lib/phantomjs.js
@@ -41,7 +41,7 @@ exports.version = '2.1.1'
  */
 exports.cleanPath = function (path) {
   return path
-      .replace(/:[^:]*node_modules[^:]*/g, '')
+      .replace(/(^|:)[^:]*node_modules[^:]*/g, '')
       .replace(/(^|:)\.\/bin(\:|$)/g, ':')
       .replace(/^:+/, '')
       .replace(/:+$/, '')


### PR DESCRIPTION
cleanPath is not working when node_modules is first in path. Something like **'/some/path/node_modules/.bin:/usr/bin'** won't be cleaned by helper