### PR TITLE
support for node 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: node_js
 sudo: false
 node_js:
+  - "8" 
   - "5"
   - "4"
   - "0.12"


### PR DESCRIPTION
With `travis`, I'm getting this error:
```
warning fsevents@1.1.2: The platform "linux" is incompatible with this module.
info "fsevents@1.1.2" is an optional dependency and failed compatibility check. Excluding it from installation.
```