### PR TITLE
Force a fixed version for `request` dependency due to non-availabilit…

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "hasha": "^2.2.0",
     "kew": "^0.7.0",
     "progress": "^1.1.8",
-    "request": "^2.81.0",
+    "request": "2.83.0",
     "request-progress": "^2.0.1",
     "which": "^1.2.10"
   },


### PR DESCRIPTION
…y of async/await function sin NodeJS versions 6.x/7x.

`request` upgraded its version from 2.83.0 to 2.84.0, commiting a version change on its *package.json* file for the `hawk` NPM dependency, from 6.x to 7.x.

Such `hawk` dependency version refers to the `sntp` library, which uses *async/await* statements in its codebase.

Due to this dependency chain, new installs of `phantomjs` fail in environments that use NodeJS versions 6.x or 7.x, since these node versions do not support the async/await functions by default.