### PR TITLE
Upgrade request to 2.85.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "hasha": "^2.2.0",
     "kew": "^0.7.0",
     "progress": "^1.1.8",
-    "request": "^2.81.0",
+    "request": "^2.85.0",
     "request-progress": "^2.0.1",
     "which": "^1.2.10"
   },


### PR DESCRIPTION
I keep getting emails from GitHub saying I have a security risk in a dependency to "hoek < 4.2.1", so I identified this repo as the user of an older version of request->hawk 3.1.3->boom 2.10.0->hoek (vulnerable).  Bumping the version works for me, but I have not tested this extensively. 